### PR TITLE
Implement script to sync users and teams from YAML into DynamoDB

### DIFF
--- a/meal-planner-task2/.gitignore
+++ b/meal-planner-task2/.gitignore
@@ -1,4 +1,3 @@
-data/
 node_modules/
 dist/
 .env

--- a/meal-planner-task2/.gitignore
+++ b/meal-planner-task2/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .env
 scripts/.test-keypair.json
+data/shared-local-instance.db

--- a/meal-planner-task2/backend/package-lock.json
+++ b/meal-planner-task2/backend/package-lock.json
@@ -17,7 +17,8 @@
         "discord-interactions": "^3.4.0",
         "dotenv": "^17.2.4",
         "express": "^5.2.1",
-        "express-validator": "^7.3.1"
+        "express-validator": "^7.3.1",
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -3447,6 +3448,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/meal-planner-task2/backend/package.json
+++ b/meal-planner-task2/backend/package.json
@@ -24,7 +24,8 @@
     "discord-interactions": "^3.4.0",
     "dotenv": "^17.2.4",
     "express": "^5.2.1",
-    "express-validator": "^7.3.1"
+    "express-validator": "^7.3.1",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/meal-planner-task2/backend/package.json
+++ b/meal-planner-task2/backend/package.json
@@ -10,7 +10,9 @@
     "build:cron": "esbuild src/jobs/cronLambda.ts --bundle --platform=node --target=node18 --external:@aws-sdk --outfile=dist/cron.js",
     "build": "npm run build:api && npm run build:cron",
     "tables:create": "tsx scripts/createTables.ts",
-    "users:sync": "tsx scripts/syncUsers.ts"
+    "teams:sync": "tsx scripts/syncTeams.ts",
+    "users:sync": "tsx scripts/syncUsers.ts",
+    "sync": "npm run teams:sync && npm run users:sync"
   },
   "keywords": [],
   "author": "",

--- a/meal-planner-task2/backend/scripts/data/teams.yaml
+++ b/meal-planner-task2/backend/scripts/data/teams.yaml
@@ -1,0 +1,10 @@
+# Team definitions
+# leadId must match a userId in users.yaml
+
+- teamId: team-engineering
+  name: Engineering
+  leadId: usr-002
+
+- teamId: team-marketing
+  name: Marketing
+  leadId: usr-005

--- a/meal-planner-task2/backend/scripts/data/users.yaml
+++ b/meal-planner-task2/backend/scripts/data/users.yaml
@@ -1,0 +1,62 @@
+# User definitions
+# userId:    stable identifier assigned by admin (never changes)
+# discordId: Discord snowflake ID (from Discord developer tools or right-click user)
+# role:      ADMIN | LEAD | LOGISTICS | EMPLOYEE
+# status:    ACTIVE | INACTIVE
+# teamId:    must match a teamId in teams.yaml, or null
+
+- userId: usr-001
+  discordId: "111111111111111111"
+  name: Alice Admin
+  email: alice@company.com
+  role: ADMIN
+  status: ACTIVE
+  teamId: null
+
+- userId: usr-002
+  discordId: "222222222222222222"
+  name: Sarah Lead
+  email: sarah@company.com
+  role: LEAD
+  status: ACTIVE
+  teamId: team-engineering
+
+- userId: usr-003
+  discordId: "333333333333333333"
+  name: Bob Employee
+  email: bob@company.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: team-engineering
+
+- userId: usr-004
+  discordId: "444444444444444444"
+  name: Carol Employee
+  email: carol@company.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: team-engineering
+
+- userId: usr-005
+  discordId: "555555555555555555"
+  name: Dan Lead
+  email: dan@company.com
+  role: LEAD
+  status: ACTIVE
+  teamId: team-marketing
+
+- userId: usr-006
+  discordId: "666666666666666666"
+  name: Eve Logistics
+  email: eve@company.com
+  role: LOGISTICS
+  status: ACTIVE
+  teamId: null
+
+- userId: usr-007
+  discordId: "777777777777777777"
+  name: Frank Former
+  email: frank@company.com
+  role: EMPLOYEE
+  status: INACTIVE
+  teamId: team-marketing

--- a/meal-planner-task2/backend/scripts/syncTeams.ts
+++ b/meal-planner-task2/backend/scripts/syncTeams.ts
@@ -1,0 +1,47 @@
+import 'dotenv/config'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
+import { PutCommand } from '@aws-sdk/lib-dynamodb'
+import { dynamo, TABLES } from '../src/config/dynamoClient.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+interface TeamYaml {
+  teamId: string
+  name:   string
+  leadId: string
+}
+
+function loadTeams(): TeamYaml[] {
+  const file = readFileSync(join(__dirname, 'data/teams.yaml'), 'utf8')
+  return parse(file) as TeamYaml[]
+}
+
+async function syncTeams() {
+  const teams = loadTeams()
+  console.log(`\nSyncing ${teams.length} team(s) → ${TABLES.TEAMS}\n`)
+
+  for (const team of teams) {
+    const now = new Date().toISOString()
+
+    await dynamo.send(new PutCommand({
+      TableName: TABLES.TEAMS,
+      Item: {
+        teamId:    team.teamId,
+        name:      team.name,
+        leadId:    team.leadId,
+        // memberIds is not set here — syncUsers.ts populates it via ADD
+        createdAt: now,
+        updatedAt: now,
+      },
+    }))
+
+    console.log(`  ✓ ${team.teamId}  (${team.name})`)
+  }
+
+  console.log('\nDone. Run npm run users:sync next to populate team members.\n')
+}
+
+syncTeams().catch(err => { console.error(err); process.exit(1) })

--- a/meal-planner-task2/backend/scripts/syncUsers.ts
+++ b/meal-planner-task2/backend/scripts/syncUsers.ts
@@ -1,0 +1,120 @@
+import 'dotenv/config'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
+import { PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { dynamo, TABLES } from '../src/config/dynamoClient.js'
+import type { Role, UserStatus } from '../src/types/index.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+interface UserYaml {
+  userId:    string
+  discordId: string
+  name:      string
+  email:     string
+  role:      Role
+  status:    UserStatus
+  teamId:    string | null
+}
+
+interface TeamYaml {
+  teamId: string
+  name:   string
+  leadId: string
+}
+
+function loadUsers(): UserYaml[] {
+  const file = readFileSync(join(__dirname, 'data/users.yaml'), 'utf8')
+  return parse(file) as UserYaml[]
+}
+
+function loadTeams(): TeamYaml[] {
+  const file = readFileSync(join(__dirname, 'data/teams.yaml'), 'utf8')
+  return parse(file) as TeamYaml[]
+}
+
+function getCurrentMonthKey(): string {
+  return new Date().toISOString().slice(0, 7) // YYYY-MM
+}
+
+async function syncUsers() {
+  const users   = loadUsers()
+  const teams   = loadTeams()
+  const teamMap = new Map(teams.map(t => [t.teamId, t.name]))
+
+  console.log(`\nSyncing ${users.length} user(s) → ${TABLES.MAIN}\n`)
+
+  const now          = new Date().toISOString()
+  const wfhMonth     = getCurrentMonthKey()
+  const activeIds: string[] = []
+
+  for (const user of users) {
+    const teamName = user.teamId ? (teamMap.get(user.teamId) ?? undefined) : undefined
+
+    // ── Upsert user PROFILE ────────────────────────────────────────────────
+    await dynamo.send(new PutCommand({
+      TableName: TABLES.MAIN,
+      Item: {
+        PK:        `USER#${user.userId}`,
+        SK:        'PROFILE',
+        userId:    user.userId,
+        name:      user.name,
+        email:     user.email,
+        discordId: user.discordId,
+        role:      user.role,
+        status:    user.status,
+        teamId:    user.teamId   ?? undefined,
+        teamName:  teamName      ?? undefined,
+        wfhCount:  0,
+        wfhMonth,
+        gsi1pk:    user.discordId,  // discordId-index
+        createdAt: now,
+        updatedAt: now,
+      },
+    }))
+
+    console.log(`  ✓ ${user.userId}  ${user.name.padEnd(20)} [${user.role}] [${user.status}]`)
+
+    // ── Sync team membership ───────────────────────────────────────────────
+    if (user.teamId) {
+      if (user.status === 'ACTIVE') {
+        await dynamo.send(new UpdateCommand({
+          TableName:                 TABLES.TEAMS,
+          Key:                       { teamId: user.teamId },
+          UpdateExpression:          'ADD memberIds :uid',
+          ExpressionAttributeValues: { ':uid': new Set([user.userId]) },
+        }))
+      } else {
+        // Remove inactive users from team so headcounts stay accurate
+        await dynamo.send(new UpdateCommand({
+          TableName:                 TABLES.TEAMS,
+          Key:                       { teamId: user.teamId },
+          UpdateExpression:          'DELETE memberIds :uid',
+          ExpressionAttributeValues: { ':uid': new Set([user.userId]) },
+        }))
+      }
+    }
+
+    if (user.status === 'ACTIVE') activeIds.push(user.userId)
+  }
+
+  // ── Upsert SYSTEM/ACTIVE_USERS sentinel ───────────────────────────────────
+  // Used by the cron Lambda to get all active users without a table scan
+  if (activeIds.length > 0) {
+    await dynamo.send(new PutCommand({
+      TableName: TABLES.MAIN,
+      Item: {
+        PK:        'SYSTEM',
+        SK:        'ACTIVE_USERS',
+        memberIds: new Set(activeIds),
+      },
+    }))
+    console.log(`\n  ✓ SYSTEM/ACTIVE_USERS updated  (${activeIds.length} active users)`)
+  }
+
+  console.log('\nDone.\n')
+}
+
+syncUsers().catch(err => { console.error(err); process.exit(1) })


### PR DESCRIPTION
Closes #33 

## What does this PR do?
Introduces the user and team sync scripts that populate DynamoDB from YAML files. This is the prerequisite for all Discord commands — every command resolves the caller's identity against data seeded by these scripts.

## Type of Change

- [x] New feature

## What was changed

**YAML data files (`scripts/data/`)**

- `teams.yaml` — team definitions: `teamId`, `name`, `leadId`
- `users.yaml` — user definitions: `userId`, `discordId`, `name`, `email`, `role`, `status`, `teamId`. Covers all roles (ADMIN, LEAD, LOGISTICS, EMPLOYEE) and both statuses (ACTIVE, INACTIVE)

**scripts/syncTeams.ts**

Reads `teams.yaml` and upserts each team into the `teams` table. `memberIds` is intentionally omitted here — `syncUsers` populates it so re-running `syncTeams` never wipes existing membership.

**scripts/syncUsers.ts**

Reads `users.yaml` and for each user:
- Upserts a `PROFILE` item into `mealPlanner` (`PK=USER#{userId}`, `SK=PROFILE`) with `gsi1pk=discordId` for the `discordId-index` lookup
- Denormalizes `teamName` from `teams.yaml` so headcount queries need no extra lookup
- Active users with a team: `ADD userId` to `teams.memberIds` StringSet
- Inactive users with a team: `DELETE userId` from `teams.memberIds`
- Upserts `SYSTEM/ACTIVE_USERS` sentinel with all active user IDs — used by the nightly cron to avoid a full table scan

**npm scripts**

| Script | Command |
|---|---|
| `npm run teams:sync` | sync teams only |
| `npm run users:sync` | sync users only |
| `npm run sync` | both in order (teams first) |

## Changelog

None: not user visible — admin-only tooling

## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2


## How to Test

1. Start DynamoDB Local: `docker compose up -d`
2. Create tables: `npm run tables:create`
3. Run full sync: `npm run sync`
4. Verify a user profile: `aws dynamodb get-item --table-name mealPlanner --key '{"PK":{"S":"USER#usr-001"},"SK":{"S":"PROFILE"}}' --endpoint-url http://localhost:8000 --region ap-southeast-1`
5. Verify team membership: `aws dynamodb get-item --table-name teams --key '{"teamId":{"S":"team-engineering"}}' --endpoint-url http://localhost:8000 --region ap-southeast-1`
6. Verify SYSTEM sentinel: `aws dynamodb get-item --table-name mealPlanner --key '{"PK":{"S":"SYSTEM"},"SK":{"S":"ACTIVE_USERS"}}' --endpoint-url http://localhost:8000 --region ap-southeast-1`

## How QA Should Test

- After `npm run sync`, all 7 sample users have PROFILE items in `mealPlanner`
- `team-engineering.memberIds` contains active members only (not `usr-007` who is INACTIVE)
- `SYSTEM/ACTIVE_USERS.memberIds` contains all 6 active users
- Re-running `npm run sync` produces the same result (idempotent)


