### PR TITLE
Implemented meal schedule management via Discord slash commands

### DIFF
--- a/meal-planner-task2/backend/scripts/createTables.ts
+++ b/meal-planner-task2/backend/scripts/createTables.ts
@@ -15,10 +15,10 @@ const client = new DynamoDBClient(
 )
 
 
-const MAIN      = process.env.DYNAMODB_TABLE_MAIN      || 'mealPlanner'
-const SCHEDULES = process.env.DYNAMODB_TABLE_SCHEDULES || 'mealSchedules'
-const TEAMS     = process.env.DYNAMODB_TABLE_TEAMS     || 'teams'
-const WFH       = process.env.DYNAMODB_TABLE_WFH       || 'globalWfhPeriods'
+const MAIN      = process.env.DYNAMODB_TABLE_MAIN      || 'trainee-2026-rifat-mealPlanner'
+const SCHEDULES = process.env.DYNAMODB_TABLE_SCHEDULES || 'trainee-2026-rifat-mealSchedules'
+const TEAMS     = process.env.DYNAMODB_TABLE_TEAMS     || 'trainee-2026-rifat-teams'
+const WFH       = process.env.DYNAMODB_TABLE_WFH       || 'trainee-2026-rifat-globalWfhPeriods'
 
 async function createIfNotExists(params: CreateTableCommandInput) {
   try {

--- a/meal-planner-task2/backend/scripts/data/users.yaml
+++ b/meal-planner-task2/backend/scripts/data/users.yaml
@@ -15,17 +15,17 @@
 
 - userId: usr-002
   discordId: "222222222222222222"
-  name: Sarah Lead
+  name: Sarah 
   email: sarah@company.com
-  role: LEAD
+  role: EMPLOYEE
   status: ACTIVE
   teamId: team-engineering
 
 - userId: usr-003
   discordId: "333333333333333333"
-  name: Bob Employee
+  name: Bob 
   email: bob@company.com
-  role: EMPLOYEE
+  role: LEAD
   status: ACTIVE
   teamId: team-engineering
 
@@ -50,7 +50,7 @@
   name: Eve Logistics
   email: eve@company.com
   role: LOGISTICS
-  status: ACTIVE
+  status: INACTIVE
   teamId: null
 
 - userId: usr-007
@@ -58,7 +58,7 @@
   name: Frank Former
   email: frank@company.com
   role: EMPLOYEE
-  status: INACTIVE
+  status: ACTIVE
   teamId: team-marketing
 
 - userId: usr-008

--- a/meal-planner-task2/backend/scripts/data/users.yaml
+++ b/meal-planner-task2/backend/scripts/data/users.yaml
@@ -60,3 +60,12 @@
   role: EMPLOYEE
   status: INACTIVE
   teamId: team-marketing
+
+- userId: usr-008
+  discordId: "1467732201599664230"
+  name: Rifat Ahmed
+  email: rifat@craftsmen.com
+  role: ADMIN
+  status: ACTIVE
+  teamId: null
+

--- a/meal-planner-task2/backend/src/app.ts
+++ b/meal-planner-task2/backend/src/app.ts
@@ -14,7 +14,6 @@ app.use('/discord', discordRouter)
 
 app.use(express.json())
 
-
 // ── Health check ──────────────────────────────────────────────────────────────
 app.get('/health', (_req: Request, res: Response) => {
   res.json({ status: 'OK', timestamp: new Date().toISOString() })

--- a/meal-planner-task2/backend/src/commands/createSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/createSchedule.ts
@@ -1,0 +1,61 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { createMealSchedule } from '../services/adminService.js'
+
+interface DiscordOption {
+  name: string
+  value: string | boolean | number
+}
+
+function opt<T>(options: DiscordOption[], name: string): T {
+  return options.find(o => o.name === name)?.value as T
+}
+
+export async function handleCreateSchedule(req: AuthRequest, res: Response): Promise<void> {
+  if (req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can create schedules.', flags: 64 } })
+    return
+  }
+
+  const options: DiscordOption[] = req.body.data?.options ?? []
+
+  const date                 = opt<string>(options, 'date')
+  const lunchEnabled         = opt<boolean>(options, 'lunch_enabled')
+  const snacksEnabled        = opt<boolean>(options, 'snacks_enabled')
+  const iftarEnabled         = opt<boolean>(options, 'iftar_enabled')
+  const eventDinnerEnabled   = opt<boolean>(options, 'event_dinner_enabled')
+  const optionalDinnerEnabled = opt<boolean>(options, 'optional_dinner_enabled')
+  const occasionName         = opt<string | undefined>(options, 'occasion_name')
+
+  // Validate date is at least tomorrow
+  const inputDate = new Date(date + 'T00:00:00')
+  const tomorrow  = new Date()
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  tomorrow.setHours(0, 0, 0, 0)
+  if (inputDate < tomorrow) {
+    res.json({ type: 4, data: { content: 'Schedule date must be at least tomorrow.', flags: 64 } })
+    return
+  }
+
+  await createMealSchedule(
+    { date, lunchEnabled, snacksEnabled, iftarEnabled, eventDinnerEnabled, optionalDinnerEnabled, occasionName },
+    req.user!.userId,
+  )
+
+  const meals = [
+    lunchEnabled         && 'Lunch',
+    snacksEnabled        && 'Snacks',
+    iftarEnabled         && 'Iftar',
+    eventDinnerEnabled   && 'Event Dinner',
+    optionalDinnerEnabled && 'Optional Dinner',
+  ].filter(Boolean).join(', ') || 'None'
+
+  const extra = occasionName ? ` — *${occasionName}*` : ''
+  res.json({
+    type: 4,
+    data: {
+      content: `Schedule created for **${date}**${extra}\nMeals enabled: ${meals}`,
+      flags: 64,
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/commands/createSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/createSchedule.ts
@@ -55,7 +55,6 @@ export async function handleCreateSchedule(req: AuthRequest, res: Response): Pro
     type: 4,
     data: {
       content: `Schedule created for **${date}**${extra}\nMeals enabled: ${meals}`,
-      flags: 64,
     },
   })
 }

--- a/meal-planner-task2/backend/src/commands/deleteSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/deleteSchedule.ts
@@ -1,0 +1,21 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { deleteMealSchedule } from '../services/adminService.js'
+
+export async function handleDeleteSchedule(req: AuthRequest, res: Response): Promise<void> {
+  if (req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can delete schedules.', flags: 64 } })
+    return
+  }
+
+  const options: Array<{ name: string; value: string }> = req.body.data?.options ?? []
+  const date = options.find(o => o.name === 'date')?.value ?? ''
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    res.json({ type: 4, data: { content: 'Invalid date format. Use YYYY-MM-DD.', flags: 64 } })
+    return
+  }
+
+  await deleteMealSchedule(date)
+  res.json({ type: 4, data: { content: `Schedule for **${date}** deleted.`, flags: 64 } })
+}

--- a/meal-planner-task2/backend/src/commands/listSchedules.ts
+++ b/meal-planner-task2/backend/src/commands/listSchedules.ts
@@ -1,0 +1,32 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { getAllMealSchedules } from '../services/adminService.js'
+
+export async function handleListSchedules(_req: AuthRequest, res: Response): Promise<void> {
+  const schedules = await getAllMealSchedules()
+
+  if (schedules.length === 0) {
+    res.json({ type: 4, data: { content: 'No upcoming meal schedules found.', flags: 64 } })
+    return
+  }
+
+  const lines = schedules.map(s => {
+    const meals = [
+      s.lunchEnabled         && 'L',
+      s.snacksEnabled        && 'S',
+      s.iftarEnabled         && 'I',
+      s.eventDinnerEnabled   && 'ED',
+      s.optionalDinnerEnabled && 'OD',
+    ].filter(Boolean).join(' ')
+    const occasion = s.occasionName ? ` *(${s.occasionName})*` : ''
+    return `**${s.date}** — ${meals || 'none'}${occasion}`
+  })
+
+  res.json({
+    type: 4,
+    data: {
+      content: `**Upcoming meal schedules:**\n${lines.join('\n')}\n\n*L=Lunch S=Snacks I=Iftar ED=EventDinner OD=OptionalDinner*`,
+      flags: 64,
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/config/dynamoClient.ts
+++ b/meal-planner-task2/backend/src/config/dynamoClient.ts
@@ -12,8 +12,8 @@ export const dynamo = DynamoDBDocumentClient.from(raw, {
 })
 
 export const TABLES = {
-  MAIN:      process.env.DYNAMODB_TABLE_MAIN      || 'mealPlanner',
-  SCHEDULES: process.env.DYNAMODB_TABLE_SCHEDULES || 'mealSchedules',
-  TEAMS:     process.env.DYNAMODB_TABLE_TEAMS     || 'teams',
-  WFH:       process.env.DYNAMODB_TABLE_WFH       || 'globalWfhPeriods',
+  MAIN:      process.env.DYNAMODB_TABLE_MAIN      || 'trainee-2026-rifat-mealPlanner',
+  SCHEDULES: process.env.DYNAMODB_TABLE_SCHEDULES || 'trainee-2026-rifat-mealSchedules',
+  TEAMS:     process.env.DYNAMODB_TABLE_TEAMS     || 'trainee-2026-rifat-teams',
+  WFH:       process.env.DYNAMODB_TABLE_WFH       || 'trainee-2026-rifat-globalWfhPeriods',
 } as const

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -1,27 +1,32 @@
 import { Response } from 'express'
 import { AuthRequest } from '../types/index.js'
+import { handleCreateSchedule } from '../commands/createSchedule.js'
+import { handleListSchedules }  from '../commands/listSchedules.js'
+import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
 
 /**
  * Entry point for all Discord slash commands.
  * Runs after discordVerify (signature checked, PING handled)
  * and discordAuth (req.user populated).
- *
- * Future features will add command-specific handlers imported here.
  */
-export const handleInteraction = (req: AuthRequest, res: Response): void => {
+export const handleInteraction = async (req: AuthRequest, res: Response): Promise<void> => {
   const { type, data } = req.body as { type: number; data?: { name?: string } }
 
   // APPLICATION_COMMAND (type 2)
   if (type === 2) {
-    const commandName = data?.name ?? 'unknown'
-    // TODO: dispatch to feature-specific command handlers (F2+)
-    res.json({
-      type: 4, // CHANNEL_MESSAGE_WITH_SOURCE
-      data: {
-        content: `Command \`/${commandName}\` is not yet implemented.`,
-        flags: 64, // EPHEMERAL
-      },
-    })
+    try {
+      switch (data?.name) {
+        case 'create-schedule': await handleCreateSchedule(req, res); return
+        case 'list-schedules':  await handleListSchedules(req, res);  return
+        case 'delete-schedule': await handleDeleteSchedule(req, res); return
+        default:
+          res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
+          return
+      }
+    } catch (err) {
+      console.error('Command handler error:', err)
+      res.json({ type: 4, data: { content: 'An internal error occurred. Please try again.', flags: 64 } })
+    }
     return
   }
 

--- a/meal-planner-task2/backend/src/middleware/discordAuth.ts
+++ b/meal-planner-task2/backend/src/middleware/discordAuth.ts
@@ -4,27 +4,10 @@ import { AuthRequest, Role } from '../types/index.js'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 
 /**
- * Resolves the highest-privilege app role from the user's Discord role IDs.
- * Role snowflake IDs are configured via env vars.
- * Precedence: ADMIN > LEAD > LOGISTICS > EMPLOYEE (default)
- */
-function resolveRole(discordRoles: string[]): Role {
-  if (process.env.DISCORD_ROLE_ADMIN && discordRoles.includes(process.env.DISCORD_ROLE_ADMIN)) {
-    return 'ADMIN'
-  }
-  if (process.env.DISCORD_ROLE_LEAD && discordRoles.includes(process.env.DISCORD_ROLE_LEAD)) {
-    return 'LEAD'
-  }
-  if (process.env.DISCORD_ROLE_LOGISTICS && discordRoles.includes(process.env.DISCORD_ROLE_LOGISTICS)) {
-    return 'LOGISTICS'
-  }
-  return 'EMPLOYEE'
-}
-
-/**
  * Extracts identity from the verified Discord interaction payload.
  * Must run after discordVerify (req.body is already the parsed interaction object).
  *
+ * Role is read from the DynamoDB user record (source of truth).
  * Sets req.user = { userId, discordId, role, teamId? }
  */
 export const discordAuth = async (
@@ -36,12 +19,9 @@ export const discordAuth = async (
   const discordId   = interaction?.member?.user?.id as string | undefined
 
   if (!discordId) {
-    res.status(401).json({ error: 'Missing Discord user identity in interaction payload' })
+    res.json({ type: 4, data: { content: 'Could not identify your Discord user.', flags: 64 } })
     return
   }
-
-  const discordRoles: string[] = interaction.member?.roles ?? []
-  const role = resolveRole(discordRoles)
 
   try {
     const result = await dynamo.send(new QueryCommand({
@@ -54,14 +34,14 @@ export const discordAuth = async (
 
     const user = result.Items?.[0]
     if (!user) {
-      res.status(403).json({ error: 'User not registered. Ask an admin to add you.' })
+      res.json({ type: 4, data: { content: 'You are not registered in the system. Ask an admin to add you.', flags: 64 } })
       return
     }
 
     req.user = {
       userId:    user['userId'] as string,
       discordId,
-      role,
+      role:      user['role'] as Role,
       teamId:    user['teamId'] as string | undefined,
     }
     next()

--- a/meal-planner-task2/backend/src/services/adminService.ts
+++ b/meal-planner-task2/backend/src/services/adminService.ts
@@ -1,0 +1,50 @@
+import { PutCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { dynamo, TABLES } from '../config/dynamoClient.js'
+import { getTodayString } from '../utils/dateHelpers.js'
+import type { CreateScheduleData, MealScheduleItem } from '../types/index.js'
+
+// ── Meal Schedule ─────────────────────────────────────────────────────────────
+
+export async function createMealSchedule(
+  data: CreateScheduleData,
+  createdBy: string,
+): Promise<void> {
+  const now = new Date().toISOString()
+  await dynamo.send(new PutCommand({
+    TableName: TABLES.SCHEDULES,
+    Item: {
+      date:                  data.date,
+      lunchEnabled:          data.lunchEnabled,
+      snacksEnabled:         data.snacksEnabled,
+      iftarEnabled:          data.iftarEnabled,
+      eventDinnerEnabled:    data.eventDinnerEnabled,
+      optionalDinnerEnabled: data.optionalDinnerEnabled,
+      occasionName:          data.occasionName,
+      createdBy,
+      createdAt: now,
+      updatedAt: now,
+    } satisfies MealScheduleItem,
+  }))
+}
+
+export async function getAllMealSchedules(): Promise<MealScheduleItem[]> {
+  const today = getTodayString()
+
+  // Scan is acceptable here — mealSchedules holds at most ~30 items at any time
+  const result = await dynamo.send(new ScanCommand({
+    TableName:                 TABLES.SCHEDULES,
+    FilterExpression:          '#d >= :today',
+    ExpressionAttributeNames:  { '#d': 'date' },  // 'date' is a DynamoDB reserved word
+    ExpressionAttributeValues: { ':today': today },
+  }))
+
+  return ((result.Items ?? []) as MealScheduleItem[])
+    .sort((a, b) => a.date.localeCompare(b.date))
+}
+
+export async function deleteMealSchedule(date: string): Promise<void> {
+  await dynamo.send(new DeleteCommand({
+    TableName: TABLES.SCHEDULES,
+    Key: { date },
+  }))
+}

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config'
 import { REST } from '@discordjs/rest'
-import { Routes } from 'discord-api-types/v10'
+import { Routes, ApplicationCommandOptionType } from 'discord-api-types/v10'
 import type { RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v10'
 
 /**
@@ -12,7 +12,71 @@ import type { RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v
  * (global commands take up to 1 hour to propagate).
  */
 const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
-  // TODO: import and add command definitions here (F2+)
+  // ── F2: Meal Schedule Management ──────────────────────────────────────────
+  {
+    name: 'create-schedule',
+    description: 'Create a meal schedule for a future date (Admin only)',
+    options: [
+      {
+        name: 'date',
+        description: 'Date in YYYY-MM-DD format (must be tomorrow or later)',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      {
+        name: 'lunch_enabled',
+        description: 'Enable lunch for this date?',
+        type: ApplicationCommandOptionType.Boolean,
+        required: true,
+      },
+      {
+        name: 'snacks_enabled',
+        description: 'Enable snacks for this date?',
+        type: ApplicationCommandOptionType.Boolean,
+        required: true,
+      },
+      {
+        name: 'iftar_enabled',
+        description: 'Enable iftar for this date?',
+        type: ApplicationCommandOptionType.Boolean,
+        required: true,
+      },
+      {
+        name: 'event_dinner_enabled',
+        description: 'Enable event dinner for this date?',
+        type: ApplicationCommandOptionType.Boolean,
+        required: true,
+      },
+      {
+        name: 'optional_dinner_enabled',
+        description: 'Enable optional dinner for this date?',
+        type: ApplicationCommandOptionType.Boolean,
+        required: true,
+      },
+      {
+        name: 'occasion_name',
+        description: 'Optional occasion name (e.g. "Team offsite")',
+        type: ApplicationCommandOptionType.String,
+        required: false,
+      },
+    ],
+  },
+  {
+    name: 'list-schedules',
+    description: 'List all upcoming meal schedules',
+  },
+  {
+    name: 'delete-schedule',
+    description: 'Delete a meal schedule by date (Admin only)',
+    options: [
+      {
+        name: 'date',
+        description: 'Date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    ],
+  },
 ]
 
 const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN!)


### PR DESCRIPTION
Closes #34 

## What does this PR do?

Admins can create, list, and delete meal schedules directly from Discord slash commands.

## Type of Change

- [x] New feature

## What was changed

- `adminService`: `createMealSchedule`, `getAllMealSchedules`, `deleteMealSchedule` backed by DynamoDB
- `src/commands/createSchedule.ts`, `listSchedules.ts`, `deleteSchedule.ts` — handlers call the service directly, no REST layer
- `discordController`: dispatches by `data.name` with a top-level try/catch so any error returns an ephemeral Discord message instead of hanging
- `discordAuth`: role now read from DynamoDB record instead of Discord guild role IDs and auth failures now return Discord interaction format (`type: 4`) instead of HTTP 4xx, which Discord cannot process
- `deploy-commands.ts`: registers `/create-schedule`, `/list-schedules`, `/delete-schedule`

## Changelog

Feature: Admins can create, list, and delete meal schedules via `/create-schedule`, `/list-schedules`, `/delete-schedule` Discord slash commands

## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2

## How to Test

1. Run `npm run deploy-commands` from `discord-bot/` to register the new commands
2. Restart the backend server
3. Type `/create-schedule` in Discord, fill in the options, and submit

## How QA Should Test

Affected workflows:
- Admin meal schedule creation, listing, and deletion via Discord

Specific checks:
- `/create-schedule` with a future date → success message; schedule appears in `/list-schedules`
- `/create-schedule` with today's or a past date → validation error message
- `/delete-schedule` → confirm removal reflected in `/list-schedules`
- Non-admin user → receives "Only admins can..." ephemeral message
- Unregistered Discord user → receives "You are not registered" ephemeral message


---