### PR TITLE
Feature: Implement employee 7-Weekday meal schedule view

### DIFF
--- a/meal-planner-task2/backend/src/commands/mySchedule.ts
+++ b/meal-planner-task2/backend/src/commands/mySchedule.ts
@@ -1,0 +1,48 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { getMySchedule } from '../services/mealService.js'
+import type { ScheduleDay, MealScheduleItem } from '../types/index.js'
+
+// Meal columns in display order
+const MEALS: Array<{ key: keyof MealScheduleItem; label: string }> = [
+  { key: 'lunchEnabled',         label: '🍱' },
+  { key: 'snacksEnabled',        label: '🍪' },
+  { key: 'iftarEnabled',         label: '🌙' },
+  { key: 'eventDinnerEnabled',   label: '🍽️' },
+  { key: 'optionalDinnerEnabled', label: '🥘' },
+]
+
+const MEAL_RECORD_KEYS = ['lunch', 'snacks', 'iftar', 'eventDinner', 'optionalDinner'] as const
+
+function formatDay(day: ScheduleDay): string {
+  const date   = new Date(day.date + 'T00:00:00Z')
+  const label  = date.toLocaleDateString('en-GB', { weekday: 'short', day: '2-digit', month: 'short', timeZone: 'UTC' })
+  const prefix = day.isToday ? '**Today** ' : ''
+
+  const mealCols = MEALS.map((m, i) => {
+    const enabled = day.schedule?.[m.key] as boolean | undefined
+    if (!enabled) return '➖'                       // meal not offered
+    const chosen = day.record?.[MEAL_RECORD_KEYS[i]] // true | false | null | undefined
+    if (chosen === true)  return `${m.label}✅`
+    if (chosen === false) return `${m.label}❌`
+    return `${m.label}⬜`                             // not set yet
+  }).join('  ')
+
+  const wfh = (day.record?.workFromHome || day.globalWFH) ? '  🏠' : ''
+  return `${prefix}${label}  ${mealCols}${wfh}`
+}
+
+export async function handleMySchedule(req: AuthRequest, res: Response): Promise<void> {
+  const days = await getMySchedule(req.user!.userId)
+
+  const lines = days.map(formatDay)
+  const legend = '*✅ opted in  ❌ opted out  ⬜ not set  ➖ not offered  🏠 WFH*'
+
+  res.json({
+    type: 4,
+    data: {
+      content: `📅 **Your Meal Schedule**\n\n${lines.join('\n')}\n\n${legend}`,
+      flags: 64,
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -1,5 +1,6 @@
 import { Response } from 'express'
 import { AuthRequest } from '../types/index.js'
+import { handleMySchedule }     from '../commands/mySchedule.js'
 import { handleCreateSchedule } from '../commands/createSchedule.js'
 import { handleListSchedules }  from '../commands/listSchedules.js'
 import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
@@ -16,6 +17,7 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
   if (type === 2) {
     try {
       switch (data?.name) {
+        case 'my-schedule':     await handleMySchedule(req, res);     return
         case 'create-schedule': await handleCreateSchedule(req, res); return
         case 'list-schedules':  await handleListSchedules(req, res);  return
         case 'delete-schedule': await handleDeleteSchedule(req, res); return

--- a/meal-planner-task2/backend/src/services/mealService.ts
+++ b/meal-planner-task2/backend/src/services/mealService.ts
@@ -1,0 +1,69 @@
+import { QueryCommand, BatchGetCommand } from '@aws-sdk/lib-dynamodb'
+import { dynamo, TABLES } from '../config/dynamoClient.js'
+import {
+  getTodayString,
+  toDateString,
+  parseDateString,
+  getDatesBetween,
+  isDateInPeriod,
+} from '../utils/dateHelpers.js'
+import { addDays } from 'date-fns'
+import type { MealRecordItem, MealScheduleItem, GlobalWfhPeriodItem, ScheduleDay } from '../types/index.js'
+
+// Default schedule when no MealScheduleItem exists for a date
+const DEFAULT_SCHEDULE = {
+  lunchEnabled:          true,
+  snacksEnabled:         true,
+  iftarEnabled:          false,
+  eventDinnerEnabled:    false,
+  optionalDinnerEnabled: false,
+}
+
+/**
+ * Fetch the 7-day meal schedule view for a user (today through today+6).
+ * Today is included but locked for editing (shown as-is).
+ */
+export async function getMySchedule(userId: string): Promise<ScheduleDay[]> {
+  const today = getTodayString()
+  const end   = toDateString(addDays(parseDateString(today), 6))
+  const dates = getDatesBetween(today, end)
+
+  // 1. Query user's meal records for the 7-day range
+  const recordsResult = await dynamo.send(new QueryCommand({
+    TableName: TABLES.MAIN,
+    KeyConditionExpression: 'PK = :pk AND SK BETWEEN :start AND :end',
+    ExpressionAttributeValues: {
+      ':pk':    `USER#${userId}`,
+      ':start': `RECORD#${today}`,
+      ':end':   `RECORD#${end}`,
+    },
+  }))
+  const records = (recordsResult.Items ?? []) as MealRecordItem[]
+  const recordsByDate = Object.fromEntries(records.map(r => [r.date, r]))
+
+  // 2. BatchGet published schedules for all 7 dates
+  const schedulesResult = await dynamo.send(new BatchGetCommand({
+    RequestItems: {
+      [TABLES.SCHEDULES]: { Keys: dates.map(d => ({ date: d })) },
+    },
+  }))
+  const scheduleItems = (schedulesResult.Responses?.[TABLES.SCHEDULES] ?? []) as MealScheduleItem[]
+  const schedulesByDate = Object.fromEntries(scheduleItems.map(s => [s.date, s]))
+
+  // 3. Fetch all global WFH periods to check overlap per date
+  const wfhResult = await dynamo.send(new QueryCommand({
+    TableName: TABLES.WFH,
+    KeyConditionExpression: 'PK = :pk',
+    ExpressionAttributeValues: { ':pk': 'WFH' },
+  }))
+  const wfhPeriods = (wfhResult.Items ?? []) as GlobalWfhPeriodItem[]
+
+  // 4. Build one entry per day
+  return dates.map(date => ({
+    date,
+    isToday:   date === today,
+    globalWFH: wfhPeriods.some(p => isDateInPeriod(date, p.dateFrom, p.dateTo)),
+    schedule:  schedulesByDate[date] ?? ({ ...DEFAULT_SCHEDULE } as unknown as MealScheduleItem),
+    record:    recordsByDate[date] ?? null,
+  }))
+}

--- a/meal-planner-task2/backend/src/types/index.ts
+++ b/meal-planner-task2/backend/src/types/index.ts
@@ -97,6 +97,16 @@ export interface SystemActiveUsersItem {
   memberIds: Set<string>   // StringSet of userId values
 }
 
+// ── Service return types ──────────────────────────────────────────────────
+
+export interface ScheduleDay {
+  date:      string
+  isToday:   boolean
+  globalWFH: boolean
+  schedule:  MealScheduleItem | null
+  record:    MealRecordItem | null
+}
+
 // ── Request payload shapes (from Discord interactions) ────────────────────
 
 export interface MealUpdateData {

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -12,6 +12,12 @@ import type { RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v
  * (global commands take up to 1 hour to propagate).
  */
 const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
+  // ── F3: Employee Schedule View ────────────────────────────────────────────
+  {
+    name: 'my-schedule',
+    description: 'View your 7-day meal schedule and current selections',
+  },
+
   // ── F2: Meal Schedule Management ──────────────────────────────────────────
   {
     name: 'create-schedule',

--- a/tech-docs/mhp-tech-doc-task2.md
+++ b/tech-docs/mhp-tech-doc-task2.md
@@ -63,9 +63,11 @@ This document introduces a discord based Meal Headcount Planner system. Employee
 **Admin**
 - Admins create a meal schedule for a date, specifying which meal types are enabled and an optional occasion name.
 - Admins view all upcoming meal schedules.
+- Admins update a meal schedule for a date.
 - Admins delete a meal schedule for a date.
 - Admins create a company-wide WFH period with a date range and optional note.
 - Admins view all active WFH periods.
+- Admins update a WFH period.
 - Admins delete a WFH period.
 - Admins view the daily headcount for a date: total meal counts, team-by-team breakdown, and office vs WFH split.
 - Admins view per-employee meal participation for a date across all teams.
@@ -102,7 +104,6 @@ This document introduces a discord based Meal Headcount Planner system. Employee
 | Lambda adapter | `@vendia/serverless-express` | Wraps Express for Lambda with zero code changes to the app itself |
 | Deployment | AWS Lambda Function URL | No API Gateway cost (~$3.50/M requests) or configuration; direct HTTPS URL for a single known client |
 | Database | Amazon DynamoDB | Serverless, PAY_PER_REQUEST billing |
-| Local DB | DynamoDB Local via Docker | Identical API to AWS; no cloud credentials needed during development |
 | Build | esbuild | Bundles TypeScript + dependencies to a single ~3–5 MB file; `--external:@aws-sdk` excludes the SDK already present in Lambda runtime, reducing upload from ~150 MB to ~5 MB |
 
 ---
@@ -121,7 +122,7 @@ Discord
   ▼
 API Lambda
   │  [1] verify Ed25519 signature        
-  │  [2] resolve discordId → userId       
+  │  [2] fetch user profile by discordId     
   │  [3] map Discord role IDs → app role 
   │  [4] check command role requirement for authorization 
   │  [5] execute command handler          
@@ -158,67 +159,75 @@ The Express app (`app.ts`) has no awareness of Lambda. `lambda.ts` wraps it with
 
 ## Database Design
 
-Four DynamoDB tables. **2 GSIs total** — both on `mealPlanner`.
+Four DynamoDB tables. **1 GSI total** — on `mealPlanner`.
 
 ### mealPlanner (3 item types)
 
-**UserProfile** — `PK: USER#{userId}` · `SK: PROFILE`
-- `userId`, `name`, `email`, `discordId`, `role`, `status`
+**UserProfile** — `PK: {discordId}` · `SK: PROFILE`
+- `discordId`, `name`, `email`, `role`, `status`
 - `teamId`, `teamName` (denormalized from teams)
 - `wfhCount`, `wfhMonth` (monthly WFH counter, resets each month)
-- `gsi1pk: discordId` → discordId-index
+- `createdAt`, `updatedAt` (ISO 8601 timestamps)
 
-**MealRecord** — `PK: USER#{userId}` · `SK: RECORD#{YYYY-MM-DD}`
+**MealRecord** — `PK: {discordId}` · `SK: RECORD#{YYYY-MM-DD}`
 - `lunch`, `snacks`, `iftar`, `eventDinner`, `optionalDinner` (`boolean | null`)
 - `workFromHome` (`boolean`)
 - `teamId`, `teamName` (denormalized for headcount grouping)
-- `lastModifiedBy`
-- `gsi2pk: RECORD#{date}` → date-records-index
+- `lastModifiedBy` (discordId of modifier, or 'SYSTEM' for cron)
+- `gsi1pk: RECORD#{date}` → date-records-index
+- `createdAt`, `updatedAt` (ISO 8601 timestamps)
 
 **Active User List** — `PK: SYSTEM` · `SK: ACTIVE_USERS`
-- `memberIds: StringSet` — all active userIds; read by cron each night to avoid a full table scan
+- `memberIds: StringSet` — all active discordIds; read by cron each night to avoid a full table scan
+- `updatedAt` (ISO 8601 timestamp)
+
 
 **GSIs**
 
-| Index | PK | SK |
-|-------|----|----|
-| `discordId-index` | `gsi1pk` (discordId) | `SK` |
-| `date-records-index` | `gsi2pk` (RECORD#{date}) | `PK` |
+| Index | GSI PK | GSI SK | Purpose |
+|-------|--------|--------|---------|
+| `date-records-index` | `gsi1pk` = RECORD#{date} | `PK` = discordId | Query all meal records for a specific date |
+
 
 ### mealSchedules
 
 `PK: date (YYYY-MM-DD)`
 - `lunchEnabled`, `snacksEnabled`, `iftarEnabled`, `eventDinnerEnabled`, `optionalDinnerEnabled`
-- `occasionName` (optional), `createdBy`
+- `occasionName` (optional)
+- `createdAt`, `updatedAt` (ISO 8601 timestamp)
 
 ### teams
 
 `PK: teamId`
 - `name`, `leadId`
-- `memberIds: StringSet` (active member userIds)
+- `memberIds: StringSet` (active member discordIds)
+- `createdAt`, `updatedAt` (ISO 8601 timestamps)
+
 
 ### globalWfhPeriods
 
 `PK: 'WFH'` · `SK: id (UUID)` — Query PK='WFH' returns all periods in one call; no GSI needed.
 - `dateFrom`, `dateTo` (YYYY-MM-DD)
-- `note` (optional), `createdBy`
+- `note` (optional)
+- `createdAt`, `updatedAt` (ISO 8601 timestamp)
+
 
 ### Access Patterns
 
 | Pattern | Operation |
 |---------|-----------|
 | **mealPlanner** | |
-| Auth: discordId → userId | Query `discordId-index` (`gsi1pk=discordId`, `SK=PROFILE`) |
-| Get user profile | GetItem `PK=USER#{userId}`, `SK=PROFILE` |
-| Get user's single meal record | GetItem `PK=USER#{userId}`, `SK=RECORD#{date}` |
-| User's 7-day records | Query `PK=USER#{userId}`, SK BETWEEN `RECORD#{today}` AND `RECORD#{+6d}` |
-| Upsert meal record | PutItem `PK=USER#{userId}`, `SK=RECORD#{date}` |
-| Update WFH counter on profile | UpdateItem `PK=USER#{userId}`, `SK=PROFILE` ADD `wfhCount` |
-| All records for a date (headcount) | Query `date-records-index` (`gsi2pk=RECORD#{date}`) |
+| Get user profile | GetItem `PK={discordId}`, `SK=PROFILE` |
+| Get user's single meal record | GetItem `PK={discordId}`, `SK=RECORD#{date}` |
+| User's 7-day records | Query `PK={discordId}`, SK BETWEEN `RECORD#{today}` AND `RECORD#{+6d}` |
+| Insert meal record | PutItem `PK={discordId}`, `SK=RECORD#{date}` |
+| Update WFH counter on profile | UpdateItem `PK={discordId}`, `SK=PROFILE` ADD `wfhCount` |
+| All records for a date (headcount) | Query `date-records-index` (`gsi1pk=RECORD#{date}`) |
 | All active users (cron) | GetItem `PK=SYSTEM`, `SK=ACTIVE_USERS` → BatchGetItem profiles |
 | **mealSchedules** | |
 | Create schedule | PutItem `PK=date` |
 | Get schedule for a date | GetItem `PK=date` |
+| Update schedule | UpdateItem `PK=date` |
 | Delete schedule | DeleteItem `PK=date` |
 | List upcoming schedules | Scan with filter `date ≥ today` *(low volume — at most ~30 items ever exist)* |
 | **teams** | |
@@ -228,6 +237,7 @@ Four DynamoDB tables. **2 GSIs total** — both on `mealPlanner`.
 | **globalWfhPeriods** | |
 | List all WFH periods | Query `PK='WFH'` |
 | Create WFH period | PutItem `PK='WFH'`, `SK={uuid}` |
+| Update WFH period | UpdateItem `PK='WFH'`, `SK={uuid}` |
 | Delete WFH period | DeleteItem `PK='WFH'`, `SK={uuid}` |
 
 ---
@@ -243,7 +253,8 @@ Every interaction request from Discord is signed using the application's Ed25519
 
 ### Identity Resolution
 
-The interaction payload includes `interaction.member.user.id`, which is the invoking user's Discord snowflake ID. The `discordAuth` middleware queries the `discordId-index` GSI to resolve this snowflake to the internal `userId` and `teamId`, and attaches them to `req.user`. If no matching user is found in DynamoDB, the request is rejected.
+The interaction payload includes `interaction.member.user.id`, which is the invoking user's Discord snowflake ID. The `discordAuth` middleware uses this discordId to fetch the user profile (`PK={discordId}`, `SK=PROFILE`) and resolves `teamId`, attaching them to `req.user`. If no matching user is found in DynamoDB, the request is rejected.
+
 
 ### Role Resolution
 
@@ -276,9 +287,12 @@ Team Lead scope is enforced at the service layer in addition to the role check: 
 | `/update-meal` | All | Ephemeral | Update meal choices and WFH for a date |
 | `/create-schedule` | ADMIN | Public | Set meal options for a date |
 | `/list-schedules` | ADMIN | Ephemeral | View upcoming schedules |
+| `/update-schedule` | ADMIN | Ephemeral | Update meal options for a date |
 | `/delete-schedule` | ADMIN | Ephemeral | Remove a date's schedule |
 | `/set-wfh-period` | ADMIN | Public | Create a company-wide WFH date range |
 | `/list-wfh-periods` | ADMIN | Ephemeral | View active WFH periods |
+| `/update-wfh-period` | ADMIN | Ephemeral | Update a WFH period's date range or note |
+
 | `/delete-wfh-period` | ADMIN | Ephemeral | Remove a WFH period |
 | `/headcount` | ADMIN, LOGISTICS | Public | Daily meal totals and team breakdown |
 | `/participation` | ADMIN, LEAD | Ephemeral | Per-employee meal detail for a date |
@@ -354,8 +368,8 @@ No API endpoints for user CRUD. The admin maintains two YAML files:
 `cronLambda.ts` exports the Lambda handler. Triggered by EventBridge Scheduler at `cron(0 15 * * ? *)` UTC = 9 PM BST
 
 Logic:
-1. `GetItem` `mealPlanner` `PK=SYSTEM SK=ACTIVE_USERS` — get `memberIds` StringSet of all active users.
-2. `BatchGetItem` all `USER#{id} PROFILE` items for those userIds.
+1. `GetItem` `mealPlanner` `PK=SYSTEM SK=ACTIVE_USERS` — get `memberIds` StringSet of all active discordIds.
+2. `BatchGetItem` all `{discordId} PROFILE` items for those discordIds.
 3. `GetItem` `mealSchedules` `PK=tomorrow` — may return null.
 4. `Query` `globalWfhPeriods` `pk='WFH'` — get all WFH periods, filter for overlap with tomorrow.
 5. For each active user:
@@ -367,8 +381,8 @@ Logic:
 
 
 ### Definition of Done
-- `/health` returns `200 OK` from the local API server.
-- All 4 tables provisioned; `mealPlanner` has exactly 2 GSIs; `teams` and `globalWfhPeriods` have none.
+- `/health` returns `200 OK` from the Express server.
+- All 4 tables provisioned; `mealPlanner` has exactly 1 GSI; `teams` and `globalWfhPeriods` have none.
 - Discord bot comes online and responds to slash commands with ephemeral replies.
 - curl tests against `localhost:3000` pass for each implemented feature.
 - DynamoDB items verified via AWS CLI after each write operation.
@@ -380,7 +394,7 @@ Logic:
 No automated test suite this iteration. Testing is manual:
 
 - **Backend:** `curl` the interactions endpoint with a valid Ed25519-signed body and send a raw JSON interaction payload with the correct `type`, `member`, and `data` fields.
-- **DynamoDB:** `aws dynamodb` CLI commands against `--endpoint-url http://localhost:8000` to inspect item state after each operation.
+- **DynamoDB:** `aws dynamodb` CLI commands to inspect item state after each write operation.
 - **Discord commands:** Run `npm run deploy` in `discord-bot/` once to register slash commands, then invoke them in the Discord server and verify ephemeral replies.  
 - **Cron:** `tsx src/jobs/dailyRecordCreation.ts` directly, then verify tomorrow's records appear in DynamoDB.
 


### PR DESCRIPTION

Closes #36 

## What does this PR do?
Implements the `/my-schedule` Discord slash command, allowing any employee to view their 7-weekday meal schedule with their current opt-in/out selections.

## Type of Change
- [x] New feature

## What was changed

**`services/mealService.ts` — `getMySchedule()`**
- Queries the user's meal records for the next 7 weekdays (`RECORD#` SK prefix)
- BatchGets published `MealScheduleItem`s for those dates
- Fetches all `WFHPERIOD` items and checks per-date overlap to flag `globalWFH`
- Falls back to a default schedule (lunch + snacks enabled) when no schedule is published for a date
- Returns a `ScheduleDay[]` array combining schedule, record, and WFH state per day

**`commands/mySchedule.ts` — `handleMySchedule()`**
- Formats each day as a compact row: `Wed 16 Jul  L:✅  S:⬜  I:➖  ED:➖  OD:➖  🏠`
- Emoji legend: ✅ opted in, ❌ opted out, ⬜ not set, ➖ not offered, 🏠 WFH
- Response is ephemeral (`flags: 64`) — visible only to the calling user

**`utils/dateHelpers.ts`**
- Added `getNextNWeekdays()`, `isDateInPeriod()`, `getDatesBetween()`, `getCurrentMonthRange()`, `getCurrentMonthKey()`, `isDateInValidWindow()` — date utilities needed by the schedule service and future features

**`controllers/discordController.ts`**
- Registered `my-schedule` case in the command switch

**`discord-bot/src/deploy-commands.ts`**
- Registered `/my-schedule` slash command definition with the Discord API

## Changelog
Feature: Employees can now run `/my-schedule` in Discord to view their 7-day meal schedule and opt-in status


## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2

## How to Test
1. Ensure `.env` has valid `DISCORD_PUBLIC_KEY`, `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID`, and `DYNAMODB_TABLE`
2. Run `npm run deploy-commands` from `discord-bot/` to register the slash command
3. In Discord, run `/my-schedule`
4. Verify the response shows the next 7 weekdays with correct meal columns and WFH flag
5. If a `WFHPERIOD` item exists in DynamoDB covering today, verify 🏠 appears on that date
