### PR TITLE
feature: add /update-schedule command in both Discord and Google Chat

### DIFF
--- a/meal-planner-task2/backend/src/commands/updateSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/updateSchedule.ts
@@ -1,0 +1,97 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { updateMealScheduleWithAudit } from '../services/adminService.js'
+
+interface DiscordOption {
+  name: string
+  value: string | boolean | number
+}
+
+function opt<T>(options: DiscordOption[], name: string): T | undefined {
+  const found = options.find(o => o.name === name)
+  return found !== undefined ? (found.value as T) : undefined
+}
+
+export async function handleUpdateSchedule(req: AuthRequest, res: Response): Promise<void> {
+  if (req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can update schedules.', flags: 64 } })
+    return
+  }
+
+  let date: string
+  let lunchEnabled:          boolean | undefined
+  let snacksEnabled:         boolean | undefined
+  let iftarEnabled:          boolean | undefined
+  let eventDinnerEnabled:    boolean | undefined
+  let optionalDinnerEnabled: boolean | undefined
+  let occasionName:          string | undefined
+
+  if (req.user!.platform === 'google') {
+    const argText = (req.body?.message?.argumentText as string ?? '').trim()
+    const occasionMatch = argText.match(/occasion:(.+)/)
+    occasionName = occasionMatch ? occasionMatch[1].trim() : undefined
+    const argsWithoutOccasion = argText.replace(/occasion:.+/, '').trim()
+    const parts = argsWithoutOccasion.split(/\s+/)
+    date = parts[0] ?? ''
+    const meals = parts.slice(1).map(m => m.toLowerCase())
+    if (meals.length > 0) {
+      lunchEnabled          = meals.includes('lunch')
+      snacksEnabled         = meals.includes('snacks')
+      iftarEnabled          = meals.includes('iftar')
+      eventDinnerEnabled    = meals.includes('eventdinner')
+      optionalDinnerEnabled = meals.includes('optionaldinner')
+    }
+  } else {
+    const options: DiscordOption[] = req.body.data?.options ?? []
+    date                  = opt<string>(options, 'date') ?? ''
+    lunchEnabled          = opt<boolean>(options, 'lunch_enabled')
+    snacksEnabled         = opt<boolean>(options, 'snacks_enabled')
+    iftarEnabled          = opt<boolean>(options, 'iftar_enabled')
+    eventDinnerEnabled    = opt<boolean>(options, 'event_dinner_enabled')
+    optionalDinnerEnabled = opt<boolean>(options, 'optional_dinner_enabled')
+    occasionName          = opt<string>(options, 'occasion_name')
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    res.json({ type: 4, data: { content: 'Invalid date format. Use YYYY-MM-DD.', flags: 64 } })
+    return
+  }
+
+  const inputDate = new Date(date + 'T00:00:00Z')
+  const tomorrow  = new Date()
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+  tomorrow.setUTCHours(0, 0, 0, 0)
+  if (inputDate < tomorrow) {
+    res.json({ type: 4, data: { content: 'Cannot update a schedule for today or a past date.', flags: 64 } })
+    return
+  }
+
+  const dow = inputDate.getUTCDay()
+  if (dow === 0 || dow === 6) {
+    res.json({ type: 4, data: { content: 'Schedules cannot be updated for weekends (Sat/Sun).', flags: 64 } })
+    return
+  }
+
+  const hasUpdate = [lunchEnabled, snacksEnabled, iftarEnabled, eventDinnerEnabled, optionalDinnerEnabled, occasionName]
+    .some(v => v !== undefined)
+  if (!hasUpdate) {
+    res.json({ type: 4, data: { content: 'Provide at least one field to update.', flags: 64 } })
+    return
+  }
+
+  try {
+    await updateMealScheduleWithAudit(
+      date,
+      { lunchEnabled, snacksEnabled, iftarEnabled, eventDinnerEnabled, optionalDinnerEnabled, occasionName },
+      req.user!.discordId,
+    )
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.startsWith('No schedule found')) {
+      res.json({ type: 4, data: { content: `No schedule exists for **${date}**. Create one first with \`/create-schedule\`.`, flags: 64 } })
+      return
+    }
+    throw err
+  }
+
+  res.json({ type: 4, data: { content: `Schedule for **${date}** updated.`, flags: 64 } })
+}

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -4,6 +4,7 @@ import { handleMySchedule }     from '../commands/mySchedule.js'
 import { handleCreateSchedule } from '../commands/createSchedule.js'
 import { handleListSchedules }  from '../commands/listSchedules.js'
 import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
+import { handleUpdateSchedule } from '../commands/updateSchedule.js'
 
 /**
  * Entry point for all Discord slash commands.
@@ -21,6 +22,7 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
         case 'create-schedule': await handleCreateSchedule(req, res); return
         case 'list-schedules':  await handleListSchedules(req, res);  return
         case 'delete-schedule': await handleDeleteSchedule(req, res); return
+        case 'update-schedule': await handleUpdateSchedule(req, res); return
         default:
           res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
           return

--- a/meal-planner-task2/backend/src/controllers/googleController.ts
+++ b/meal-planner-task2/backend/src/controllers/googleController.ts
@@ -4,6 +4,7 @@ import { handleMySchedule }     from '../commands/mySchedule.js'
 import { handleCreateSchedule } from '../commands/createSchedule.js'
 import { handleListSchedules }  from '../commands/listSchedules.js'
 import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
+import { handleUpdateSchedule } from '../commands/updateSchedule.js'
 
 /**
  * Entry point for all Google Chat slash commands.
@@ -31,6 +32,7 @@ export const handleGoogleInteraction = async (req: AuthRequest, res: Response): 
       case 'create-schedule': await handleCreateSchedule(req, res); return
       case 'list-schedules':  await handleListSchedules(req, res);  return
       case 'delete-schedule': await handleDeleteSchedule(req, res); return
+      case 'update-schedule': await handleUpdateSchedule(req, res); return
       default:
         res.json({ text: `Unknown command \`/${commandName}\`.` })
     }

--- a/meal-planner-task2/backend/src/services/adminService.ts
+++ b/meal-planner-task2/backend/src/services/adminService.ts
@@ -1,8 +1,8 @@
-import { PutCommand, DeleteCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
+import { PutCommand, GetCommand, UpdateCommand, DeleteCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import { getTodayString } from '../utils/dateHelpers.js'
 import { writeAuditLog } from './auditService.js'
-import type { CreateScheduleData, MealScheduleItem } from '../types/index.js'
+import type { CreateScheduleData, UpdateScheduleData, MealScheduleItem } from '../types/index.js'
 
 // ── Meal Schedule ─────────────────────────────────────────────────────────────
 
@@ -45,6 +45,65 @@ export async function createMealSchedule(
       optionalDinnerEnabled: { old: null, new: data.optionalDinnerEnabled },
       occasionName:          { old: null, new: data.occasionName ?? null },
     },
+  })
+}
+
+export async function updateMealScheduleWithAudit(
+  date: string,
+  data: UpdateScheduleData,
+  actorDiscordId: string,
+): Promise<void> {
+  const existing = await dynamo.send(new GetCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'SCHEDULE', SK: date },
+  }))
+
+  if (!existing.Item) {
+    throw new Error(`No schedule found for ${date}`)
+  }
+
+  const old = existing.Item as MealScheduleItem
+  const now  = new Date().toISOString()
+
+  const setClauses: string[]                               = ['updatedAt = :updatedAt']
+  const exprValues: Record<string, unknown>                = { ':updatedAt': now }
+  const changes:    Record<string, { old: unknown; new: unknown }> = {}
+
+  const boolFields = [
+    'lunchEnabled',
+    'snacksEnabled',
+    'iftarEnabled',
+    'eventDinnerEnabled',
+    'optionalDinnerEnabled',
+  ] as const
+
+  for (const field of boolFields) {
+    if (data[field] !== undefined) {
+      setClauses.push(`${field} = :${field}`)
+      exprValues[`:${field}`] = data[field]
+      changes[field] = { old: old[field], new: data[field] }
+    }
+  }
+
+  if (data.occasionName !== undefined) {
+    setClauses.push('occasionName = :occasionName')
+    exprValues[':occasionName'] = data.occasionName
+    changes['occasionName'] = { old: old.occasionName ?? null, new: data.occasionName }
+  }
+
+  await dynamo.send(new UpdateCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'SCHEDULE', SK: date },
+    UpdateExpression: `SET ${setClauses.join(', ')}`,
+    ExpressionAttributeValues: exprValues,
+  }))
+
+  await writeAuditLog({
+    actorDiscordId,
+    actorName:  actorDiscordId,
+    action:     'UPDATE',
+    entityType: 'SCHEDULE',
+    entityId:   date,
   })
 }
 

--- a/meal-planner-task2/backend/src/types/index.ts
+++ b/meal-planner-task2/backend/src/types/index.ts
@@ -138,6 +138,15 @@ export interface CreateScheduleData {
   occasionName?:         string
 }
 
+export interface UpdateScheduleData {
+  lunchEnabled?:          boolean
+  snacksEnabled?:         boolean
+  iftarEnabled?:          boolean
+  eventDinnerEnabled?:    boolean
+  optionalDinnerEnabled?: boolean
+  occasionName?:          string
+}
+
 export interface BulkMealUpdateData {
   discordIds: string[]
   date:       string

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -83,6 +83,54 @@ const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
       },
     ],
   },
+  {
+    name: 'update-schedule',
+    description: 'Update an existing meal schedule (Admin only)',
+    options: [
+      {
+        name: 'date',
+        description: 'Date of the schedule to update (YYYY-MM-DD)',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      {
+        name: 'lunch_enabled',
+        description: 'Enable or disable lunch',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'snacks_enabled',
+        description: 'Enable or disable snacks',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'iftar_enabled',
+        description: 'Enable or disable iftar',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'event_dinner_enabled',
+        description: 'Enable or disable event dinner',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'optional_dinner_enabled',
+        description: 'Enable or disable optional dinner',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'occasion_name',
+        description: 'Update the occasion name',
+        type: ApplicationCommandOptionType.String,
+        required: false,
+      },
+    ],
+  },
 ]
 
 

--- a/task-files/task2-iteration1.md
+++ b/task-files/task2-iteration1.md
@@ -1,0 +1,26 @@
+# Project: Meal Headcount Planner (MHP) — Task 2 (Weeks 3–4)
+Add a Discord bot as an input channel while evolving MHP into a production-grade system with DynamoDB persistence, a structured web dashboard, containerized runtime, and CI/CD.
+
+## Iteration 1 (Week 1) — Discord Input + Web Dashboard Architecture (FE3 + FE4 + BE3)
+### Feature requests
+1. **Discord bot: employee self-update**
+   - Employees can update their meal participation for a selected date.
+   - Employees can update their work location (Office/WFH) for a selected date.
+   - Bot replies with the user’s current status summary after each change.
+
+2. **Discord bot: team/admin quick views**
+   - Team Leads can request a team-level headcount summary for a selected date.
+   - Admin/Logistics can request overall headcount summary for a selected date.
+
+3. **Web dashboard: component-based UI**
+   - Admin/Logistics dashboard displays meal totals, Office vs WFH split, and special-day indicators.
+   - Team Lead view displays team participation list and rollups.
+   - UI is clearly organized into reusable components (filters, summary cards, employee list, day banner).
+
+4. **Web dashboard: shared state + live updates**
+   - Dashboard supports changing selected date and filters (team, meal type, WFH).
+   - Totals and rollups update immediately as filters or entries change.
+
+5. **Compute paradigm: async summary generation**
+   - When Admin triggers “Generate daily summary”, the system processes it asynchronously.
+   - UI/bot shows “in progress” → “ready” status.

--- a/task-files/task2-iteration2.md
+++ b/task-files/task2-iteration2.md
@@ -1,0 +1,23 @@
+## Iteration 2 (Week 2) — DynamoDB + Scheduled Summaries + Docker + CI/CD (BE4 + DO1 + DO2 + BE3)
+### Feature requests
+1. **DynamoDB persistence**
+   - Persist participation entries, work-location entries, special days, and company-wide WFH periods.
+   - Reports and dashboards read from persisted data.
+
+2. **Report-ready retrieval**
+   - Admin can retrieve daily totals quickly for a selected date.
+   - Team Leads can retrieve team-level participation quickly for a selected date.
+   - Monthly WFH usage summary is available (soft limit: accept beyond 5, but flag/report it).
+
+3. **Scheduled daily post to Discord**
+   - System posts a daily summary message to a configured Discord channel at a configured time.
+   - The post includes meal totals and special-day context (holiday/office closed/celebration).
+
+4. **Containerized delivery**
+   - System runs via containers (web + backend + bot).
+   - A single “run locally” workflow exists for developers.
+
+5. **CI/CD pipeline**
+   - On pull requests: run checks and build artifacts.
+   - On merge to main: publish release artifacts (and optionally deploy to a shared internal environment).
+   - Build version is visible in the web UI and included in bot responses (basic release visibility).


### PR DESCRIPTION
Closes #34 

## What does this PR do?

Adds the `/update-schedule` slash command, completing the meal schedule management feature for both Discord and Google Chat.

## Type of Change

- [x] New feature

## What was changed

- **`types/index.ts`** — added `UpdateScheduleData` interface with all five meal toggle fields and `occasionName` as optional, allowing partial updates
- **`adminService.ts`** — added `updateMealScheduleWithAudit`: fetches the existing schedule to capture old values, builds a dynamic `SET` expression for only the supplied fields, updates `updatedAt`, and writes an `UPDATE` audit log entry
- **`commands/updateSchedule.ts`** — new shared handler (Discord + Google Chat): ADMIN-only, validates date format, rejects past dates and weekends, requires at least one field, surfaces a not-found error as an ephemeral message
- **`discordController.ts` / `googleController.ts`** — import and route `update-schedule`
- **`deploy-commands.ts`** — registers `/update-schedule` with `date` (required) and all five meal toggles plus `occasion_name` (all optional)

## Changelog

Feature: Admins can now update meal toggles and occasion name on an existing schedule via `/update-schedule`


## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2


## How to Test

1. Create a schedule with `/create-schedule` for a future weekday
2. Run `/update-schedule` with that date and one or more changed fields — confirm ephemeral success reply and updated values in DynamoDB
3. Run without any optional fields — confirm `Provide at least one field to update.`
4. Run for a date with no schedule — confirm not-found message
5. Run with a past or weekend date — confirm rejection message
6. Run as a non-admin — confirm `Only admins can update schedules.`