### PR TITLE
Implement /create-meal and /update-meal commands to manage users meal creation and update in both discord and google chat

### DIFF
--- a/meal-planner-task2/backend/scripts/data/users.yaml
+++ b/meal-planner-task2/backend/scripts/data/users.yaml
@@ -59,3 +59,101 @@
   role: ADMIN
   status: ACTIVE
   teamId: null
+
+- discordId: "1467742584200892707"
+  name: Abdullah Ghalib
+  email: abdullah.ghalib@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "1467736090244022500"
+  name: Farhan Tanvir
+  email: farhan.tanvir@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "1467727728017936477"
+  name: Mehedi Hasan
+  email: mehedi.hasan@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "1467744839943721055"
+  name: Najmul Hasan
+  email: najmul.hasan@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "1071390812547580005"
+  name: Niloy Gabriel
+  email: niloy.gabriel@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "1467742734449377402"
+  name: Samin Yasar
+  email: samin.yasar@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "1467733883842990112"
+  name: Sayad Ibn
+  email: sayad.ibn@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "905679599877365820"
+  name: Akash
+  email: akash@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "150376500577697792"
+  name: Arif
+  email: arif@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "871633031868350485"
+  name: Israjur
+  email: israjur@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "917269897229246555"
+  name: Abir
+  email: abir@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "905470178584829952"
+  name: Khirul
+  email: khirul@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "1147050401292619847"
+  name: Amir
+  email: amir@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null
+
+- discordId: "581878102075113475"
+  name: Rishadul
+  email: rishadul@craftsmensoftware.com
+  role: EMPLOYEE
+  status: ACTIVE
+  teamId: null

--- a/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
+++ b/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
@@ -1,0 +1,49 @@
+import { AuthRequest, MealUpdateData } from '../types/index.js'
+import { getTodayString, isWeekend, isDateInValidWindow } from '../utils/dateHelpers.js'
+
+interface DiscordOption {
+  name:  string
+  value: string | boolean | number
+}
+
+function opt<T>(options: DiscordOption[], name: string): T | undefined {
+  const found = options.find(o => o.name === name)
+  return found !== undefined ? (found.value as T) : undefined
+}
+
+export function parseMealOptions(req: AuthRequest): MealUpdateData {
+  if (req.user!.platform === 'google') {
+    const argText = (req.body?.message?.argumentText as string ?? '').trim()
+    const parts   = argText.split(/\s+/)
+    const date    = parts[0] ?? ''
+    const tokens  = parts.slice(1).map(t => t.toLowerCase())
+    return {
+      date,
+      lunch:          tokens.includes('lunch')          ? true : undefined,
+      snacks:         tokens.includes('snacks')         ? true : undefined,
+      iftar:          tokens.includes('iftar')          ? true : undefined,
+      eventDinner:    tokens.includes('eventdinner')    ? true : undefined,
+      optionalDinner: tokens.includes('optionaldinner') ? true : undefined,
+      workFromHome:   tokens.includes('wfh')            ? true : undefined,
+    }
+  }
+
+  const options: DiscordOption[] = req.body.data?.options ?? []
+  return {
+    date:           opt<string>(options, 'date') ?? '',
+    lunch:          opt<boolean>(options, 'lunch'),
+    snacks:         opt<boolean>(options, 'snacks'),
+    iftar:          opt<boolean>(options, 'iftar'),
+    eventDinner:    opt<boolean>(options, 'event_dinner'),
+    optionalDinner: opt<boolean>(options, 'optional_dinner'),
+    workFromHome:   opt<boolean>(options, 'work_from_home'),
+  }
+}
+
+export function validateMealDate(date: string): string | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date))  return 'Invalid date format. Use YYYY-MM-DD.'
+  if (date <= getTodayString())             return "Cannot set meals for today or a past date. Today's record is locked."
+  if (isWeekend(date))                     return 'Cannot set meals for weekends (Sat/Sun).'
+  if (!isDateInValidWindow(date))          return 'Date is outside the 7-weekday booking window.'
+  return null
+}

--- a/meal-planner-task2/backend/src/commands/createMeal.ts
+++ b/meal-planner-task2/backend/src/commands/createMeal.ts
@@ -1,0 +1,27 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { createOrUpdateMealRecord } from '../services/mealService.js'
+import { parseMealOptions, validateMealDate } from './_mealChoiceHelpers.js'
+
+export async function handleCreateMeal(req: AuthRequest, res: Response): Promise<void> {
+  const data = parseMealOptions(req)
+
+  const err = validateMealDate(data.date)
+  if (err) {
+    res.json({ type: 4, data: { content: err, flags: 64 } })
+    return
+  }
+
+  try {
+    await createOrUpdateMealRecord(data.date, data, req.user!.discordId)
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message === 'User profile not found') {
+      res.json({ type: 4, data: { content: 'Your profile was not found. Please contact an admin.', flags: 64 } })
+      return
+    }
+    throw e
+  }
+
+  const wfhNote = data.workFromHome ? ' — 🏠 WFH noted.' : '.'
+  res.json({ type: 4, data: { content: `Meal choices saved for **${data.date}**${wfhNote}`, flags: 64 } })
+}

--- a/meal-planner-task2/backend/src/commands/createMeal.ts
+++ b/meal-planner-task2/backend/src/commands/createMeal.ts
@@ -13,7 +13,7 @@ export async function handleCreateMeal(req: AuthRequest, res: Response): Promise
   }
 
   try {
-    await createOrUpdateMealRecord(data.date, data, req.user!.discordId)
+    await createOrUpdateMealRecord(req.user!.discordId, data, req.user!.discordId)
   } catch (e: unknown) {
     if (e instanceof Error && e.message === 'User profile not found') {
       res.json({ type: 4, data: { content: 'Your profile was not found. Please contact an admin.', flags: 64 } })

--- a/meal-planner-task2/backend/src/commands/updateMeal.ts
+++ b/meal-planner-task2/backend/src/commands/updateMeal.ts
@@ -13,7 +13,7 @@ export async function handleUpdateMeal(req: AuthRequest, res: Response): Promise
   }
 
   try {
-    await createOrUpdateMealRecord(data.date, data, req.user!.discordId)
+    await createOrUpdateMealRecord(req.user!.discordId, data, req.user!.discordId)
   } catch (e: unknown) {
     if (e instanceof Error && e.message === 'User profile not found') {
       res.json({ type: 4, data: { content: 'Your profile was not found. Please contact an admin.', flags: 64 } })

--- a/meal-planner-task2/backend/src/commands/updateMeal.ts
+++ b/meal-planner-task2/backend/src/commands/updateMeal.ts
@@ -1,0 +1,27 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { createOrUpdateMealRecord } from '../services/mealService.js'
+import { parseMealOptions, validateMealDate } from './_mealChoiceHelpers.js'
+
+export async function handleUpdateMeal(req: AuthRequest, res: Response): Promise<void> {
+  const data = parseMealOptions(req)
+
+  const err = validateMealDate(data.date)
+  if (err) {
+    res.json({ type: 4, data: { content: err, flags: 64 } })
+    return
+  }
+
+  try {
+    await createOrUpdateMealRecord(data.date, data, req.user!.discordId)
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message === 'User profile not found') {
+      res.json({ type: 4, data: { content: 'Your profile was not found. Please contact an admin.', flags: 64 } })
+      return
+    }
+    throw e
+  }
+
+  const wfhNote = data.workFromHome ? ' — 🏠 WFH noted.' : '.'
+  res.json({ type: 4, data: { content: `Meal choices updated for **${data.date}**${wfhNote}`, flags: 64 } })
+}

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -5,6 +5,8 @@ import { handleCreateSchedule } from '../commands/createSchedule.js'
 import { handleListSchedules }  from '../commands/listSchedules.js'
 import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
 import { handleUpdateSchedule } from '../commands/updateSchedule.js'
+import { handleCreateMeal }    from '../commands/createMeal.js'
+import { handleUpdateMeal }    from '../commands/updateMeal.js'
 
 /**
  * Entry point for all Discord slash commands.
@@ -23,6 +25,8 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
         case 'list-schedules':  await handleListSchedules(req, res);  return
         case 'delete-schedule': await handleDeleteSchedule(req, res); return
         case 'update-schedule': await handleUpdateSchedule(req, res); return
+        case 'create-meal':     await handleCreateMeal(req, res);     return
+        case 'update-meal':     await handleUpdateMeal(req, res);     return
         default:
           res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
           return

--- a/meal-planner-task2/backend/src/controllers/googleController.ts
+++ b/meal-planner-task2/backend/src/controllers/googleController.ts
@@ -5,6 +5,8 @@ import { handleCreateSchedule } from '../commands/createSchedule.js'
 import { handleListSchedules }  from '../commands/listSchedules.js'
 import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
 import { handleUpdateSchedule } from '../commands/updateSchedule.js'
+import { handleCreateMeal }    from '../commands/createMeal.js'
+import { handleUpdateMeal }    from '../commands/updateMeal.js'
 
 /**
  * Entry point for all Google Chat slash commands.
@@ -33,6 +35,8 @@ export const handleGoogleInteraction = async (req: AuthRequest, res: Response): 
       case 'list-schedules':  await handleListSchedules(req, res);  return
       case 'delete-schedule': await handleDeleteSchedule(req, res); return
       case 'update-schedule': await handleUpdateSchedule(req, res); return
+      case 'create-meal':     await handleCreateMeal(req, res);     return
+      case 'update-meal':     await handleUpdateMeal(req, res);     return
       default:
         res.json({ text: `Unknown command \`/${commandName}\`.` })
     }

--- a/meal-planner-task2/backend/src/services/mealService.ts
+++ b/meal-planner-task2/backend/src/services/mealService.ts
@@ -1,11 +1,108 @@
-import { QueryCommand, BatchGetCommand } from '@aws-sdk/lib-dynamodb'
+import { QueryCommand, BatchGetCommand, GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import {
   getTodayString,
   getNextNWeekdays,
   isDateInPeriod,
+  getCurrentMonthKey,
 } from '../utils/dateHelpers.js'
-import type { MealRecordItem, MealScheduleItem, WfhPeriodItem, ScheduleDay } from '../types/index.js'
+import { writeAuditLog } from './auditService.js'
+import type { MealRecordItem, MealScheduleItem, WfhPeriodItem, ScheduleDay, MealUpdateData, UserItem } from '../types/index.js'
+
+export async function createOrUpdateMealRecord(
+  discordId: string,
+  data: MealUpdateData,
+  actorDiscordId: string,
+): Promise<void> {
+  const now = new Date().toISOString()
+
+  // 1. Fetch user profile (required for denormalization + WFH counter)
+  const profileResult = await dynamo.send(new GetCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: `USER#${discordId}`, SK: 'PROFILE' },
+  }))
+  if (!profileResult.Item) throw new Error('User profile not found')
+  const user = profileResult.Item as UserItem
+
+  // 2. Fetch existing meal record (to carry forward unset fields + compute WFH delta)
+  const existingResult = await dynamo.send(new GetCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: `USER#${discordId}`, SK: `RECORD#${data.date}` },
+  }))
+  const existing = existingResult.Item as MealRecordItem | undefined
+
+  // 3. Resolve WFH — carry forward if not provided
+  const prevWfh = existing?.workFromHome ?? false
+  const newWfh  = data.workFromHome !== undefined ? data.workFromHome : prevWfh
+
+  // 4. Upsert the meal record (carry forward existing meal fields for omitted options)
+  await dynamo.send(new PutCommand({
+    TableName: TABLES.MAIN,
+    Item: {
+      PK:             `USER#${discordId}`,
+      SK:             `RECORD#${data.date}`,
+      discordId,
+      date:           data.date,
+      lunch:          data.lunch          !== undefined ? data.lunch          : (existing?.lunch          ?? null),
+      snacks:         data.snacks         !== undefined ? data.snacks         : (existing?.snacks         ?? null),
+      iftar:          data.iftar          !== undefined ? data.iftar          : (existing?.iftar          ?? null),
+      eventDinner:    data.eventDinner    !== undefined ? data.eventDinner    : (existing?.eventDinner    ?? null),
+      optionalDinner: data.optionalDinner !== undefined ? data.optionalDinner : (existing?.optionalDinner ?? null),
+      workFromHome:   newWfh,
+      teamId:         user.teamId,
+      teamName:       user.teamName,
+      createdAt:      existing?.createdAt ?? now,
+      updatedAt:      now,
+    } satisfies MealRecordItem,
+  }))
+
+  // 5. Update WFH counter on profile if work location changed
+  const delta = newWfh ? (prevWfh ? 0 : 1) : (prevWfh ? -1 : 0)
+  if (delta !== 0) {
+    const currentMonthKey = getCurrentMonthKey()
+    if (user.wfhMonth !== currentMonthKey) {
+      // Month rolled over — reset counter
+      await dynamo.send(new UpdateCommand({
+        TableName: TABLES.MAIN,
+        Key: { PK: `USER#${discordId}`, SK: 'PROFILE' },
+        UpdateExpression: 'SET wfhCount = :count, wfhMonth = :month, updatedAt = :now',
+        ExpressionAttributeValues: {
+          ':count': Math.max(delta, 0),
+          ':month': currentMonthKey,
+          ':now':   now,
+        },
+      }))
+    } else {
+      await dynamo.send(new UpdateCommand({
+        TableName: TABLES.MAIN,
+        Key: { PK: `USER#${discordId}`, SK: 'PROFILE' },
+        UpdateExpression: 'SET wfhCount = :count, updatedAt = :now',
+        ExpressionAttributeValues: {
+          ':count': Math.max(0, user.wfhCount + delta),
+          ':now':   now,
+        },
+      }))
+    }
+  }
+
+  // 6. Audit log
+  await writeAuditLog({
+    actorDiscordId,
+    actorName:       actorDiscordId,
+    action:          existing ? 'UPDATE' : 'CREATE',
+    entityType:      'MEAL_RECORD',
+    entityId:        `${discordId}#${data.date}`,
+    targetDiscordId: discordId,
+    changes: {
+      ...(data.lunch          !== undefined && { lunch:          { old: existing?.lunch          ?? null, new: data.lunch } }),
+      ...(data.snacks         !== undefined && { snacks:         { old: existing?.snacks         ?? null, new: data.snacks } }),
+      ...(data.iftar          !== undefined && { iftar:          { old: existing?.iftar          ?? null, new: data.iftar } }),
+      ...(data.eventDinner    !== undefined && { eventDinner:    { old: existing?.eventDinner    ?? null, new: data.eventDinner } }),
+      ...(data.optionalDinner !== undefined && { optionalDinner: { old: existing?.optionalDinner ?? null, new: data.optionalDinner } }),
+      ...(data.workFromHome   !== undefined && { workFromHome:   { old: prevWfh, new: newWfh } }),
+    },
+  })
+}
 
 // Default schedule when no MealScheduleItem exists for a date
 const DEFAULT_SCHEDULE = {


### PR DESCRIPTION

Closes #38  

## What does this PR do?

Adds `/create-meal` and `/update-meal` slash commands, giving employees a way to set and update their meal choices and WFH status for upcoming weekdays on both Discord and Google Chat.

## Type of Change

- [x] New feature

## What was changed

- **`mealService.ts`** — added `createOrUpdateMealRecord`: fetches the user profile (for teamId/teamName denormalization and WFH counter state) and any existing record (to carry forward omitted meal fields), upserts the `MealRecordItem`, updates `wfhCount`/`wfhMonth` on the profile when work location changes (resets on month rollover, floors at 0), and writes a CREATE or UPDATE audit log entry
- **`commands/_mealChoiceHelpers.ts`** — shared platform-aware option parser and date validation used by both command handlers
- **`commands/createMeal.ts`** — `/create-meal` handler (all roles)
- **`commands/updateMeal.ts`** — `/update-meal` handler (all roles)
- **`discordController.ts` / `googleController.ts`** — route both new commands
- **`deploy-commands.ts`** — register `/create-meal` and `/update-meal` with `date` (required) and five meal toggles + `work_from_home` (all optional)

## Changelog

Feature: Employees can now set and update their meal choices and WFH status for upcoming weekdays via `/create-meal` and `/update-meal`


## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2


## How to Test

1. Run `/create-meal` with a future weekday date and some meal options — confirm ephemeral success and correct DynamoDB record
2. Run `/update-meal` on the same date with different options — confirm changed fields updated, omitted fields carried forward
3. Set `work_from_home:true` then `false` — confirm `wfhCount` on user profile increments and decrements correctly
4. Test all validation cases: today, past date, weekend, beyond 7-day window