### PR TITLE
Feature: WFH period management commands for Admin (/set-wfh-period, /update-wfh-period, /list-wfh-periods, /delete-wfh-period)

### DIFF
--- a/meal-planner-task2/backend/src/commands/deleteWfhPeriod.ts
+++ b/meal-planner-task2/backend/src/commands/deleteWfhPeriod.ts
@@ -1,0 +1,31 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { deleteWfhPeriod } from '../services/wfhService.js'
+
+export async function handleDeleteWfhPeriod(req: AuthRequest, res: Response): Promise<void> {
+  if (req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can delete WFH periods.', flags: 64 } })
+    return
+  }
+
+  const id = req.user!.platform === 'google'
+    ? (req.body?.message?.argumentText as string ?? '').trim()
+    : (req.body.data?.options as Array<{ name: string; value: string }> ?? []).find(o => o.name === 'id')?.value ?? ''
+
+  if (!id) {
+    res.json({ type: 4, data: { content: 'Provide the WFH period ID (use `/list-wfh-periods` to find it).', flags: 64 } })
+    return
+  }
+
+  try {
+    await deleteWfhPeriod(id, req.user!.discordId)
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message === 'WFH period not found') {
+      res.json({ type: 4, data: { content: `No WFH period found with id \`${id}\`. Use \`/list-wfh-periods\` to check.`, flags: 64 } })
+      return
+    }
+    throw e
+  }
+
+  res.json({ type: 4, data: { content: `WFH period \`${id}\` deleted.`, flags: 64 } })
+}

--- a/meal-planner-task2/backend/src/commands/listWfhPeriods.ts
+++ b/meal-planner-task2/backend/src/commands/listWfhPeriods.ts
@@ -1,0 +1,30 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { listWfhPeriods } from '../services/wfhService.js'
+
+export async function handleListWfhPeriods(req: AuthRequest, res: Response): Promise<void> {
+  if (req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can view WFH periods.', flags: 64 } })
+    return
+  }
+
+  const periods = await listWfhPeriods()
+
+  if (periods.length === 0) {
+    res.json({ type: 4, data: { content: 'No WFH periods found.', flags: 64 } })
+    return
+  }
+
+  const lines = periods.map(p => {
+    const note = p.note ? ` — *${p.note}*` : ''
+    return `**${p.dateFrom}** → **${p.dateTo}**${note}  \`id: ${p.id}\``
+  })
+
+  res.json({
+    type: 4,
+    data: {
+      content: `**WFH Periods:**\n${lines.join('\n')}`,
+      flags: 64,
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/commands/setWfhPeriod.ts
+++ b/meal-planner-task2/backend/src/commands/setWfhPeriod.ts
@@ -1,0 +1,51 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { createWfhPeriod } from '../services/wfhService.js'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export async function handleSetWfhPeriod(req: AuthRequest, res: Response): Promise<void> {
+  if (req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can set WFH periods.', flags: 64 } })
+    return
+  }
+
+  let dateFrom: string
+  let dateTo:   string
+  let note:     string | undefined
+
+  if (req.user!.platform === 'google') {
+    const argText = (req.body?.message?.argumentText as string ?? '').trim()
+    const noteMatch = argText.match(/note:(.+)/)
+    note = noteMatch ? noteMatch[1].trim() : undefined
+    const parts = argText.replace(/note:.+/, '').trim().split(/\s+/)
+    dateFrom = parts[0] ?? ''
+    dateTo   = parts[1] ?? ''
+  } else {
+    const options: Array<{ name: string; value: string }> = req.body.data?.options ?? []
+    const opt = (name: string) => options.find(o => o.name === name)?.value
+    dateFrom = opt('date_from') ?? ''
+    dateTo   = opt('date_to')   ?? ''
+    note     = opt('note')
+  }
+
+  if (!DATE_RE.test(dateFrom) || !DATE_RE.test(dateTo)) {
+    res.json({ type: 4, data: { content: 'Invalid date format. Use YYYY-MM-DD.', flags: 64 } })
+    return
+  }
+  if (dateTo < dateFrom) {
+    res.json({ type: 4, data: { content: '`date_to` must be on or after `date_from`.', flags: 64 } })
+    return
+  }
+
+  const period = await createWfhPeriod({ dateFrom, dateTo, note }, req.user!.discordId)
+
+  const noteText = note ? ` — *${note}*` : ''
+  const idText   = `\`id: ${period.id}\``
+  res.json({
+    type: 4,
+    data: {
+      content: `🏠 **WFH period set** ${idText}\n**${dateFrom}** → **${dateTo}**${noteText}`,
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/commands/updateWfhPeriod.ts
+++ b/meal-planner-task2/backend/src/commands/updateWfhPeriod.ts
@@ -1,0 +1,72 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { updateWfhPeriod } from '../services/wfhService.js'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export async function handleUpdateWfhPeriod(req: AuthRequest, res: Response): Promise<void> {
+  if (req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can update WFH periods.', flags: 64 } })
+    return
+  }
+
+  let id:       string
+  let dateFrom: string | undefined
+  let dateTo:   string | undefined
+  let note:     string | undefined
+
+  if (req.user!.platform === 'google') {
+    const argText = (req.body?.message?.argumentText as string ?? '').trim()
+    const noteMatch     = argText.match(/note:([^\s].*)/)
+    const dateFromMatch = argText.match(/datefrom:(\d{4}-\d{2}-\d{2})/)
+    const dateToMatch   = argText.match(/dateto:(\d{4}-\d{2}-\d{2})/)
+    note     = noteMatch     ? noteMatch[1].trim()     : undefined
+    dateFrom = dateFromMatch ? dateFromMatch[1]         : undefined
+    dateTo   = dateToMatch   ? dateToMatch[1]           : undefined
+    // id is the first token before any key:value pairs
+    id = argText.split(/\s+/)[0] ?? ''
+  } else {
+    const options: Array<{ name: string; value: string }> = req.body.data?.options ?? []
+    const opt = (name: string) => options.find(o => o.name === name)?.value
+    id       = opt('id')        ?? ''
+    dateFrom = opt('date_from')
+    dateTo   = opt('date_to')
+    note     = opt('note')
+  }
+
+  if (!id) {
+    res.json({ type: 4, data: { content: 'Provide the WFH period ID (use `/list-wfh-periods` to find it).', flags: 64 } })
+    return
+  }
+
+  if (dateFrom !== undefined && !DATE_RE.test(dateFrom)) {
+    res.json({ type: 4, data: { content: 'Invalid `date_from` format. Use YYYY-MM-DD.', flags: 64 } })
+    return
+  }
+  if (dateTo !== undefined && !DATE_RE.test(dateTo)) {
+    res.json({ type: 4, data: { content: 'Invalid `date_to` format. Use YYYY-MM-DD.', flags: 64 } })
+    return
+  }
+  if (dateFrom !== undefined && dateTo !== undefined && dateTo < dateFrom) {
+    res.json({ type: 4, data: { content: '`date_to` must be on or after `date_from`.', flags: 64 } })
+    return
+  }
+
+  const hasUpdate = [dateFrom, dateTo, note].some(v => v !== undefined)
+  if (!hasUpdate) {
+    res.json({ type: 4, data: { content: 'Provide at least one field to update (`date_from`, `date_to`, or `note`).', flags: 64 } })
+    return
+  }
+
+  try {
+    await updateWfhPeriod(id, { dateFrom, dateTo, note }, req.user!.discordId)
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message === 'WFH period not found') {
+      res.json({ type: 4, data: { content: `No WFH period found with id \`${id}\`. Use \`/list-wfh-periods\` to check.`, flags: 64 } })
+      return
+    }
+    throw e
+  }
+
+  res.json({ type: 4, data: { content: `WFH period \`${id}\` updated.`, flags: 64 } })
+}

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -5,8 +5,12 @@ import { handleCreateSchedule } from '../commands/createSchedule.js'
 import { handleListSchedules }  from '../commands/listSchedules.js'
 import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
 import { handleUpdateSchedule } from '../commands/updateSchedule.js'
-import { handleCreateMeal }    from '../commands/createMeal.js'
-import { handleUpdateMeal }    from '../commands/updateMeal.js'
+import { handleCreateMeal }     from '../commands/createMeal.js'
+import { handleUpdateMeal }     from '../commands/updateMeal.js'
+import { handleSetWfhPeriod }   from '../commands/setWfhPeriod.js'
+import { handleListWfhPeriods } from '../commands/listWfhPeriods.js'
+import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
+import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 
 /**
  * Entry point for all Discord slash commands.
@@ -25,8 +29,12 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
         case 'list-schedules':  await handleListSchedules(req, res);  return
         case 'delete-schedule': await handleDeleteSchedule(req, res); return
         case 'update-schedule': await handleUpdateSchedule(req, res); return
-        case 'create-meal':     await handleCreateMeal(req, res);     return
-        case 'update-meal':     await handleUpdateMeal(req, res);     return
+        case 'create-meal':       await handleCreateMeal(req, res);       return
+        case 'update-meal':       await handleUpdateMeal(req, res);       return
+        case 'set-wfh-period':    await handleSetWfhPeriod(req, res);    return
+        case 'list-wfh-periods':  await handleListWfhPeriods(req, res);  return
+        case 'update-wfh-period': await handleUpdateWfhPeriod(req, res); return
+        case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
         default:
           res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
           return

--- a/meal-planner-task2/backend/src/controllers/googleController.ts
+++ b/meal-planner-task2/backend/src/controllers/googleController.ts
@@ -5,8 +5,12 @@ import { handleCreateSchedule } from '../commands/createSchedule.js'
 import { handleListSchedules }  from '../commands/listSchedules.js'
 import { handleDeleteSchedule } from '../commands/deleteSchedule.js'
 import { handleUpdateSchedule } from '../commands/updateSchedule.js'
-import { handleCreateMeal }    from '../commands/createMeal.js'
-import { handleUpdateMeal }    from '../commands/updateMeal.js'
+import { handleCreateMeal }     from '../commands/createMeal.js'
+import { handleUpdateMeal }     from '../commands/updateMeal.js'
+import { handleSetWfhPeriod }   from '../commands/setWfhPeriod.js'
+import { handleListWfhPeriods } from '../commands/listWfhPeriods.js'
+import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
+import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 
 /**
  * Entry point for all Google Chat slash commands.
@@ -35,8 +39,12 @@ export const handleGoogleInteraction = async (req: AuthRequest, res: Response): 
       case 'list-schedules':  await handleListSchedules(req, res);  return
       case 'delete-schedule': await handleDeleteSchedule(req, res); return
       case 'update-schedule': await handleUpdateSchedule(req, res); return
-      case 'create-meal':     await handleCreateMeal(req, res);     return
-      case 'update-meal':     await handleUpdateMeal(req, res);     return
+      case 'create-meal':       await handleCreateMeal(req, res);       return
+      case 'update-meal':       await handleUpdateMeal(req, res);       return
+      case 'set-wfh-period':    await handleSetWfhPeriod(req, res);    return
+      case 'list-wfh-periods':  await handleListWfhPeriods(req, res);  return
+      case 'update-wfh-period': await handleUpdateWfhPeriod(req, res); return
+      case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
       default:
         res.json({ text: `Unknown command \`/${commandName}\`.` })
     }

--- a/meal-planner-task2/backend/src/services/wfhService.ts
+++ b/meal-planner-task2/backend/src/services/wfhService.ts
@@ -1,0 +1,127 @@
+import { PutCommand, QueryCommand, UpdateCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb'
+import { randomUUID } from 'node:crypto'
+import { dynamo, TABLES } from '../config/dynamoClient.js'
+import { writeAuditLog } from './auditService.js'
+import type { WfhPeriodItem, CreateWfhPeriodData, UpdateWfhPeriodData } from '../types/index.js'
+
+export async function createWfhPeriod(
+  data: CreateWfhPeriodData,
+  actorDiscordId: string,
+): Promise<WfhPeriodItem> {
+  const id  = randomUUID().replace(/-/g, '').slice(0, 8)
+  const now = new Date().toISOString()
+
+  const item: WfhPeriodItem = {
+    PK:        'WFHPERIOD',
+    SK:        `${data.dateFrom}#${id}`,
+    id,
+    dateFrom:  data.dateFrom,
+    dateTo:    data.dateTo,
+    note:      data.note,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  await dynamo.send(new PutCommand({ TableName: TABLES.MAIN, Item: item }))
+
+  await writeAuditLog({
+    actorDiscordId,
+    actorName:  actorDiscordId,
+    action:     'CREATE',
+    entityType: 'WFH_PERIOD',
+    entityId:   item.SK,
+    changes: {
+      dateFrom: { old: null, new: data.dateFrom },
+      dateTo:   { old: null, new: data.dateTo },
+      note:     { old: null, new: data.note ?? null },
+    },
+  })
+
+  return item
+}
+
+export async function listWfhPeriods(): Promise<WfhPeriodItem[]> {
+  const result = await dynamo.send(new QueryCommand({
+    TableName: TABLES.MAIN,
+    KeyConditionExpression: 'PK = :pk',
+    ExpressionAttributeValues: { ':pk': 'WFHPERIOD' },
+  }))
+  return (result.Items ?? []) as WfhPeriodItem[]
+}
+
+async function findById(id: string): Promise<WfhPeriodItem | undefined> {
+  const all = await listWfhPeriods()
+  return all.find(p => p.id === id)
+}
+
+export async function updateWfhPeriod(
+  id: string,
+  data: UpdateWfhPeriodData,
+  actorDiscordId: string,
+): Promise<void> {
+  const existing = await findById(id)
+  if (!existing) throw new Error('WFH period not found')
+
+  const now = new Date().toISOString()
+  const setClauses: string[]                               = ['updatedAt = :updatedAt']
+  const exprValues: Record<string, unknown>                = { ':updatedAt': now }
+  const changes:    Record<string, { old: unknown; new: unknown }> = {}
+
+  if (data.dateFrom !== undefined) {
+    setClauses.push('dateFrom = :dateFrom')
+    exprValues[':dateFrom'] = data.dateFrom
+    changes['dateFrom'] = { old: existing.dateFrom, new: data.dateFrom }
+  }
+  if (data.dateTo !== undefined) {
+    setClauses.push('dateTo = :dateTo')
+    exprValues[':dateTo'] = data.dateTo
+    changes['dateTo'] = { old: existing.dateTo, new: data.dateTo }
+  }
+  if (data.note !== undefined) {
+    setClauses.push('note = :note')
+    exprValues[':note'] = data.note
+    changes['note'] = { old: existing.note ?? null, new: data.note }
+  }
+
+  await dynamo.send(new UpdateCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'WFHPERIOD', SK: existing.SK },
+    UpdateExpression: `SET ${setClauses.join(', ')}`,
+    ExpressionAttributeValues: exprValues,
+  }))
+
+  await writeAuditLog({
+    actorDiscordId,
+    actorName:  actorDiscordId,
+    action:     'UPDATE',
+    entityType: 'WFH_PERIOD',
+    entityId:   existing.SK,
+    changes,
+  })
+}
+
+export async function deleteWfhPeriod(
+  id: string,
+  actorDiscordId: string,
+): Promise<void> {
+  const existing = await findById(id)
+  if (!existing) throw new Error('WFH period not found')
+
+  await dynamo.send(new DeleteCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'WFHPERIOD', SK: existing.SK },
+  }))
+
+  await writeAuditLog({
+    actorDiscordId,
+    actorName:  actorDiscordId,
+    action:     'DELETE',
+    entityType: 'WFH_PERIOD',
+    entityId:   existing.SK,
+    changes: {
+      dateFrom: { old: existing.dateFrom, new: null },
+      dateTo:   { old: existing.dateTo,   new: null },
+      note:     { old: existing.note ?? null, new: null },
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/types/index.ts
+++ b/meal-planner-task2/backend/src/types/index.ts
@@ -159,6 +159,12 @@ export interface CreateWfhPeriodData {
   note?:    string
 }
 
+export interface UpdateWfhPeriodData {
+  dateFrom?: string
+  dateTo?:   string
+  note?:     string
+}
+
 // ── Service / response shapes ─────────────────────────────────────────────
 
 export interface ScheduleDayView {

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -131,6 +131,176 @@ const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
       },
     ],
   },
+
+  // ── F6: WFH Period Management ─────────────────────────────────────────────
+  {
+    name: 'set-wfh-period',
+    description: 'Create a company-wide WFH period (Admin only)',
+    options: [
+      {
+        name: 'date_from',
+        description: 'Start date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      {
+        name: 'date_to',
+        description: 'End date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      {
+        name: 'note',
+        description: 'Optional note (e.g. "Eid holidays")',
+        type: ApplicationCommandOptionType.String,
+        required: false,
+      },
+    ],
+  },
+  {
+    name: 'list-wfh-periods',
+    description: 'List all WFH periods (Admin only)',
+  },
+  {
+    name: 'update-wfh-period',
+    description: 'Update an existing WFH period (Admin only)',
+    options: [
+      {
+        name: 'id',
+        description: 'WFH period ID (from /list-wfh-periods)',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      {
+        name: 'date_from',
+        description: 'New start date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: false,
+      },
+      {
+        name: 'date_to',
+        description: 'New end date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: false,
+      },
+      {
+        name: 'note',
+        description: 'New note',
+        type: ApplicationCommandOptionType.String,
+        required: false,
+      },
+    ],
+  },
+  {
+    name: 'delete-wfh-period',
+    description: 'Delete a WFH period by ID (Admin only)',
+    options: [
+      {
+        name: 'id',
+        description: 'WFH period ID (from /list-wfh-periods)',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    ],
+  },
+
+  // ── F4: Employee Meal Choices ──────────────────────────────────────────────
+  {
+    name: 'create-meal',
+    description: 'Set your meal choices for a future weekday',
+    options: [
+      {
+        name: 'date',
+        description: 'Date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      {
+        name: 'lunch',
+        description: 'Opt in or out of lunch',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'snacks',
+        description: 'Opt in or out of snacks',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'iftar',
+        description: 'Opt in or out of iftar',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'event_dinner',
+        description: 'Opt in or out of event dinner',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'optional_dinner',
+        description: 'Opt in or out of optional dinner',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'work_from_home',
+        description: 'Are you working from home this day?',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+    ],
+  },
+  {
+    name: 'update-meal',
+    description: 'Update your meal choices for a future weekday',
+    options: [
+      {
+        name: 'date',
+        description: 'Date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      {
+        name: 'lunch',
+        description: 'Opt in or out of lunch',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'snacks',
+        description: 'Opt in or out of snacks',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'iftar',
+        description: 'Opt in or out of iftar',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'event_dinner',
+        description: 'Opt in or out of event dinner',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'optional_dinner',
+        description: 'Opt in or out of optional dinner',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+      {
+        name: 'work_from_home',
+        description: 'Are you working from home this day?',
+        type: ApplicationCommandOptionType.Boolean,
+        required: false,
+      },
+    ],
+  },
 ]
 
 


### PR DESCRIPTION

 - Closes #40

## What does this PR do?

Adds four slash commands for company-wide WFH period management, available on both Discord and Google Chat. Admins can create, list, update, and delete WFH date ranges. The `/my-schedule` view already consumes these periods to show the `🏠` WFH flag — so once a period is set, all affected dates automatically reflect it in employee schedule views.

## Type of Change

- [x] New feature

## What was changed

- **`wfhService.ts`** — four service functions: `createWfhPeriod` (generates an 8-char ID from UUID, writes audit log), `listWfhPeriods` (query all `PK=WFHPERIOD` items), `updateWfhPeriod` (resolves item by id, partial SET update, writes audit log), `deleteWfhPeriod` (resolves by id, hard delete, writes audit log)
- **`types/index.ts`** — added `UpdateWfhPeriodData` interface
- **`setWfhPeriod.ts`** — ADMIN-only, public response (no `flags: 64`), parses `date_from`/`date_to`/`note` for both platforms, validates date format and `dateTo >= dateFrom`
- **`listWfhPeriods.ts`** — ADMIN-only, ephemeral list with the 8-char `id` shown on each row so it can be copied for update/delete
- **`updateWfhPeriod.ts`** — ADMIN-only, partial update by id, validates any provided dates, rejects if no fields given
- **`deleteWfhPeriod.ts`** — ADMIN-only, hard delete by id
- **`discordController.ts` / `googleController.ts`** — route all 4 new commands
- **`deploy-commands.ts`** — register `set-wfh-period`, `list-wfh-periods`, `update-wfh-period`, `delete-wfh-period` with Discord

## Changelog

Feature: Admins can now create, list, update, and delete company-wide WFH periods via `/set-wfh-period`, `/list-wfh-periods`, `/update-wfh-period`, and `/delete-wfh-period`

 ## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2

## How to Test

Affected workflows:
- Admin WFH period lifecycle (create → list → update → delete)
- Employee `/my-schedule` WFH flag display 

Specific checks:

**Discord:**
- `/set-wfh-period date_from:2026-03-24 date_to:2026-03-26 note:Test` → public channel message with `id: <8chars>` and date range shown
- `/list-wfh-periods` → ephemeral list showing the period with its id and note
- `/update-wfh-period id:<id> date_to:2026-03-28` → ephemeral confirmation; re-run `/list-wfh-periods` and confirm `dateTo` changed
- `/update-wfh-period id:<id> note:Updated note` → only note changes, dates unchanged
- `/delete-wfh-period id:<id>` → ephemeral confirmation; `/list-wfh-periods` returns "No WFH periods found."

**Google Chat:**
- `/set-wfh-period 2026-03-24 2026-03-26 note:Test`
- `/list-wfh-periods`
- `/update-wfh-period <id> dateto:2026-03-28`
- `/delete-wfh-period <id>`

**Validation — date format:**
- `/set-wfh-period date_from:24-03-2026 date_to:2026-03-26` → "Invalid date format. Use YYYY-MM-DD."
- `/set-wfh-period date_from:2026-03-26 date_to:2026-03-24` → "`date_to` must be on or after `date_from`."
- `/update-wfh-period id:<id> date_from:bad` → "Invalid `date_from` format."
- `/update-wfh-period id:<id> date_from:2026-03-28 date_to:2026-03-25` → "`date_to` must be on or after `date_from`."

**Validation — unknown id:**
- `/update-wfh-period id:00000000 note:x` → "No WFH period found with id `00000000`."
- `/delete-wfh-period id:00000000` → "No WFH period found with id `00000000`."

**Validation — empty update:**
- `/update-wfh-period id:<id>` (no other fields) → "Provide at least one field to update."

**Authorization:**
- Non-admin user runs any of the 4 commands → "Only admins can..." ephemeral error

**DynamoDB verification:**
- After `/set-wfh-period`: confirm item exists with `PK=WFHPERIOD`, `SK={dateFrom}#{id}`, correct fields
- After `/update-wfh-period`: confirm changed fields updated, `updatedAt` changed, `createdAt` unchanged
- After `/delete-wfh-period`: confirm item no longer exists
- After each mutation: confirm audit log entry written under `PK=AUDIT#WFH_PERIOD#...`

**Schedule integration:**
- Set a WFH period covering a future weekday
- Run `/my-schedule` as an employee — confirm affected dates show `🏠`

---