### PR TITLE
Feature: Daily Headcount Reporting of total meals with team-by-team breakdown and office/WFH split for Admin and Logistics (/headcount)

### DIFF
--- a/meal-planner-task2/backend/scripts/data/teams.yaml
+++ b/meal-planner-task2/backend/scripts/data/teams.yaml
@@ -1,10 +1,14 @@
 # Team definitions
 # leadId must match a discordId in users.yaml
 
-- teamId: team-engineering
-  name: Engineering
-  leadId: "333333333333333333"
+- teamId: team-alpha
+  name: Team Alpha
+  leadId: "1467742584200892707"
 
-- teamId: team-marketing
-  name: Marketing
-  leadId: "555555555555555555"
+- teamId: team-beta
+  name: Team Beta
+  leadId: "1467742734449377402"
+
+- teamId: team-gamma
+  name: Team Gamma
+  leadId: "917269897229246555"

--- a/meal-planner-task2/backend/scripts/data/users.yaml
+++ b/meal-planner-task2/backend/scripts/data/users.yaml
@@ -4,55 +4,6 @@
 # status:    ACTIVE | INACTIVE
 # teamId:    must match a teamId in teams.yaml, or null
 
-- discordId: "111111111111111111"
-  name: Alice Admin
-  email: alice@company.com
-  role: ADMIN
-  status: ACTIVE
-  teamId: null
-
-- discordId: "222222222222222222"
-  name: Sarah
-  email: sarah@company.com
-  role: EMPLOYEE
-  status: ACTIVE
-  teamId: team-engineering
-
-- discordId: "333333333333333333"
-  name: Bob
-  email: bob@company.com
-  role: LEAD
-  status: ACTIVE
-  teamId: team-engineering
-
-- discordId: "444444444444444444"
-  name: Carol Employee
-  email: carol@company.com
-  role: EMPLOYEE
-  status: ACTIVE
-  teamId: team-engineering
-
-- discordId: "555555555555555555"
-  name: Dan Lead
-  email: dan@company.com
-  role: LEAD
-  status: ACTIVE
-  teamId: team-marketing
-
-- discordId: "666666666666666666"
-  name: Eve Logistics
-  email: eve@company.com
-  role: LOGISTICS
-  status: INACTIVE
-  teamId: null
-
-- discordId: "777777777777777777"
-  name: Frank Former
-  email: frank@company.com
-  role: EMPLOYEE
-  status: ACTIVE
-  teamId: team-marketing
-
 - discordId: "1467732201599664230"
   name: Rifat Ahmed
   email: rifat.ahmed@craftsmensoftware.com
@@ -60,100 +11,106 @@
   status: ACTIVE
   teamId: null
 
+# ── Team Alpha ────────────────────────────────────────────────────────────────
+
 - discordId: "1467742584200892707"
   name: Abdullah Ghalib
   email: abdullah.ghalib@craftsmensoftware.com
-  role: EMPLOYEE
+  role: LEAD
   status: ACTIVE
-  teamId: null
+  teamId: team-alpha
 
 - discordId: "1467736090244022500"
   name: Farhan Tanvir
   email: farhan.tanvir@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-alpha
 
 - discordId: "1467727728017936477"
   name: Mehedi Hasan
   email: mehedi.hasan@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-alpha
 
 - discordId: "1467744839943721055"
   name: Najmul Hasan
   email: najmul.hasan@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-alpha
 
 - discordId: "1071390812547580005"
   name: Niloy Gabriel
   email: niloy.gabriel@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-alpha
+
+# ── Team Beta ─────────────────────────────────────────────────────────────────
 
 - discordId: "1467742734449377402"
   name: Samin Yasar
   email: samin.yasar@craftsmensoftware.com
-  role: EMPLOYEE
+  role: LEAD
   status: ACTIVE
-  teamId: null
+  teamId: team-beta
 
 - discordId: "1467733883842990112"
   name: Sayad Ibn
   email: sayad.ibn@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-beta
 
 - discordId: "905679599877365820"
   name: Akash
   email: akash@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-beta
 
 - discordId: "150376500577697792"
   name: Arif
   email: arif@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-beta
 
 - discordId: "871633031868350485"
   name: Israjur
   email: israjur@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-beta
+
+# ── Team Gamma ────────────────────────────────────────────────────────────────
 
 - discordId: "917269897229246555"
   name: Abir
   email: abir@craftsmensoftware.com
-  role: EMPLOYEE
+  role: LEAD
   status: ACTIVE
-  teamId: null
+  teamId: team-gamma
 
 - discordId: "905470178584829952"
   name: Khirul
   email: khirul@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-gamma
 
 - discordId: "1147050401292619847"
   name: Amir
   email: amir@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-gamma
 
 - discordId: "581878102075113475"
   name: Rishadul
   email: rishadul@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
-  teamId: null
+  teamId: team-gamma

--- a/meal-planner-task2/backend/src/commands/headcount.ts
+++ b/meal-planner-task2/backend/src/commands/headcount.ts
@@ -1,0 +1,68 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { getHeadcount } from '../services/headcountService.js'
+import { getTodayString } from '../utils/dateHelpers.js'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export async function handleHeadcount(req: AuthRequest, res: Response): Promise<void> {
+  const role = req.user!.role
+  if (role !== 'ADMIN' && role !== 'LOGISTICS') {
+    res.json({ type: 4, data: { content: 'Only admins and logistics members can view headcount.', flags: 64 } })
+    return
+  }
+
+  let date: string
+  if (req.user!.platform === 'google') {
+    const arg = (req.body?.message?.argumentText as string ?? '').trim()
+    date = arg || getTodayString()
+  } else {
+    const options: Array<{ name: string; value: string }> = req.body.data?.options ?? []
+    date = options.find(o => o.name === 'date')?.value ?? getTodayString()
+  }
+
+  if (!DATE_RE.test(date)) {
+    res.json({ type: 4, data: { content: 'Invalid date format. Use YYYY-MM-DD.', flags: 64 } })
+    return
+  }
+
+  const data = await getHeadcount(date)
+
+  if (data.overallTotal === 0) {
+    res.json({ type: 4, data: { content: `No meal records found for **${date}**.` } })
+    return
+  }
+
+  const occasionLine = data.occasionName ? ` — *${data.occasionName}*` : ''
+  const { mealTotals: m, workLocationSplit: w } = data
+
+  const mealLine = [
+    m.lunch          > 0 && `🍱 Lunch: **${m.lunch}**`,
+    m.snacks         > 0 && `🍪 Snacks: **${m.snacks}**`,
+    m.iftar          > 0 && `🌙 Iftar: **${m.iftar}**`,
+    m.eventDinner    > 0 && `🍽️ Event Dinner: **${m.eventDinner}**`,
+    m.optionalDinner > 0 && `🥘 Optional Dinner: **${m.optionalDinner}**`,
+  ].filter(Boolean).join('  ') || 'No meals opted in.'
+
+  const teamLines = data.teamBreakdown.map(t => {
+    const meals = [
+      t.lunch          > 0 && `L:${t.lunch}`,
+      t.snacks         > 0 && `S:${t.snacks}`,
+      t.iftar          > 0 && `I:${t.iftar}`,
+      t.eventDinner    > 0 && `ED:${t.eventDinner}`,
+      t.optionalDinner > 0 && `OD:${t.optionalDinner}`,
+    ].filter(Boolean).join(' ') || 'none'
+    return `  **${t.teamName}** (${t.totalMembers}) — ${meals}`
+  })
+
+  const lines = [
+    `📊 **Headcount — ${date}**${occasionLine}`,
+    ``,
+    `🏢 Office: **${w.office}**  🏠 WFH: **${w.wfh}**  👥 Total: **${data.overallTotal}**`,
+    ``,
+    mealLine,
+    teamLines.length > 0 ? `\n**By team:**\n${teamLines.join('\n')}` : '',
+  ].filter(s => s !== '').join('\n')
+
+  res.json({ type: 4, data: { content: lines } })
+}

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -11,6 +11,7 @@ import { handleSetWfhPeriod }   from '../commands/setWfhPeriod.js'
 import { handleListWfhPeriods } from '../commands/listWfhPeriods.js'
 import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
+import { handleHeadcount }       from '../commands/headcount.js'
 
 /**
  * Entry point for all Discord slash commands.
@@ -35,6 +36,7 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
         case 'list-wfh-periods':  await handleListWfhPeriods(req, res);  return
         case 'update-wfh-period': await handleUpdateWfhPeriod(req, res); return
         case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
+        case 'headcount':         await handleHeadcount(req, res);       return
         default:
           res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
           return

--- a/meal-planner-task2/backend/src/controllers/googleController.ts
+++ b/meal-planner-task2/backend/src/controllers/googleController.ts
@@ -11,6 +11,7 @@ import { handleSetWfhPeriod }   from '../commands/setWfhPeriod.js'
 import { handleListWfhPeriods } from '../commands/listWfhPeriods.js'
 import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
+import { handleHeadcount }       from '../commands/headcount.js'
 
 /**
  * Entry point for all Google Chat slash commands.
@@ -45,6 +46,7 @@ export const handleGoogleInteraction = async (req: AuthRequest, res: Response): 
       case 'list-wfh-periods':  await handleListWfhPeriods(req, res);  return
       case 'update-wfh-period': await handleUpdateWfhPeriod(req, res); return
       case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
+      case 'headcount':         await handleHeadcount(req, res);       return
       default:
         res.json({ text: `Unknown command \`/${commandName}\`.` })
     }

--- a/meal-planner-task2/backend/src/services/headcountService.ts
+++ b/meal-planner-task2/backend/src/services/headcountService.ts
@@ -1,0 +1,102 @@
+import { QueryCommand, BatchGetCommand, GetCommand } from '@aws-sdk/lib-dynamodb'
+import { dynamo, TABLES } from '../config/dynamoClient.js'
+import type { UserItem, MealRecordItem, MealScheduleItem, HeadcountData } from '../types/index.js'
+
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size))
+  return chunks
+}
+
+export async function getHeadcount(date: string): Promise<HeadcountData> {
+  // 1. All active users via GSI
+  const gsiResult = await dynamo.send(new QueryCommand({
+    TableName:                 TABLES.MAIN,
+    IndexName:                 'status-email-index',
+    KeyConditionExpression:    '#status = :active',
+    ExpressionAttributeNames:  { '#status': 'status' },
+    ExpressionAttributeValues: { ':active': 'ACTIVE' },
+  }))
+  const activeUsers = (gsiResult.Items ?? []) as UserItem[]
+  const discordIds  = activeUsers.map(u => u.discordId)
+
+  // 2. BatchGet meal records for the date (chunks of 100)
+  const records: MealRecordItem[] = []
+  for (const chunk of chunkArray(discordIds, 100)) {
+    const batch = await dynamo.send(new BatchGetCommand({
+      RequestItems: {
+        [TABLES.MAIN]: {
+          Keys: chunk.map(id => ({ PK: `USER#${id}`, SK: `RECORD#${date}` })),
+        },
+      },
+    }))
+    records.push(...((batch.Responses?.[TABLES.MAIN] ?? []) as MealRecordItem[]))
+  }
+
+  // 3. Fetch schedule for occasionName
+  const scheduleResult = await dynamo.send(new GetCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'SCHEDULE', SK: date },
+  }))
+  const schedule = scheduleResult.Item as MealScheduleItem | undefined
+
+  // 4. Aggregate meal totals
+  const mealTotals = {
+    lunch:          records.filter(r => r.lunch === true).length,
+    snacks:         records.filter(r => r.snacks === true).length,
+    iftar:          records.filter(r => r.iftar === true).length,
+    eventDinner:    records.filter(r => r.eventDinner === true).length,
+    optionalDinner: records.filter(r => r.optionalDinner === true).length,
+  }
+
+  // 5. Work location split
+  const workLocationSplit = {
+    office: records.filter(r => !r.workFromHome).length,
+    wfh:    records.filter(r =>  r.workFromHome).length,
+  }
+
+  // 6. Team breakdown
+  const teamMap = new Map<string, {
+    teamName:       string
+    totalMembers:   number
+    lunch:          number
+    snacks:         number
+    iftar:          number
+    eventDinner:    number
+    optionalDinner: number
+  }>()
+
+  for (const r of records) {
+    const tid = r.teamId ?? '__none__'
+    const entry = teamMap.get(tid) ?? {
+      teamName:       r.teamName ?? tid,
+      totalMembers:   0,
+      lunch:          0,
+      snacks:         0,
+      iftar:          0,
+      eventDinner:    0,
+      optionalDinner: 0,
+    }
+    entry.totalMembers++
+    if (r.lunch          === true) entry.lunch++
+    if (r.snacks         === true) entry.snacks++
+    if (r.iftar          === true) entry.iftar++
+    if (r.eventDinner    === true) entry.eventDinner++
+    if (r.optionalDinner === true) entry.optionalDinner++
+    teamMap.set(tid, entry)
+  }
+
+  const teamBreakdown = [...teamMap.entries()]
+    .filter(([tid]) => tid !== '__none__')
+    .map(([teamId, t]) => ({ teamId, ...t }))
+    .sort((a, b) => a.teamName.localeCompare(b.teamName))
+
+  return {
+    date,
+    mealTotals,
+    teamBreakdown,
+    workLocationSplit,
+    overallTotal:  records.length,
+    occasionName:  schedule?.occasionName ?? null,
+  }
+}

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -204,6 +204,20 @@ const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
     ],
   },
 
+  // ── F7: Headcount ─────────────────────────────────────────────────────────
+  {
+    name: 'headcount',
+    description: 'View daily meal headcount and team breakdown (Admin/Logistics only)',
+    options: [
+      {
+        name: 'date',
+        description: 'Date in YYYY-MM-DD format (defaults to today)',
+        type: ApplicationCommandOptionType.String,
+        required: false,
+      },
+    ],
+  },
+
   // ── F4: Employee Meal Choices ──────────────────────────────────────────────
   {
     name: 'create-meal',


### PR DESCRIPTION
- Closes #41 

## What does this PR do?

Adds the `/headcount` slash command for ADMIN and LOGISTICS roles on both Discord and Google Chat. Takes an optional date (defaults to today) and returns a public message with total meal counts, office vs WFH split, and a per-team breakdown.

## Type of Change

- [x] New feature

## What was changed

- **`headcountService.ts`** — `getHeadcount(date)`: queries all active users via `status-email-index` GSI, batch-fetches meal records in chunks of 100, fetches the schedule item for `occasionName`, aggregates `mealTotals`, `workLocationSplit`, `teamBreakdown` (sorted by team name, excludes records with no teamId from breakdown but counts them in totals), and returns `HeadcountData`
- **`headcount.ts`** — ADMIN/LOGISTICS-only handler, optional `date` option defaults to today, validates date format, public response (no `flags: 64`), formats office/WFH split + per-meal totals + team breakdown with member count
- **`discordController.ts` / `googleController.ts`** — route `headcount` command
- **`deploy-commands.ts`** — register `/headcount` with optional `date` string option
- **`teams.yaml`** — replaced placeholder teams with three real teams: Team Alpha (lead: Abdullah Ghalib), Team Beta (lead: Samin Yasar), Team Gamma (lead: Abir)
- **`users.yaml`** — removed placeholder test users, assigned all 14 craftsmensoftware employees to teams, promoted leads to `LEAD` role

## Changelog

Feature: Admins and logistics members can now run `/headcount` to view daily meal totals, office/WFH split, and team-by-team breakdown for any date

## Test Resources
**Invitation to Discord Server:** https://discord.gg/YUubbepy
**Google Chat Space URL:** https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint:** https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table:** https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2

## How to Test

**Affected workflows:**
- Admin/Logistics daily meal oversight

**Specific checks:**

- `/headcount` with no date → returns today's data with correct totals
- `/headcount date:2026-03-24` → returns data for specified date
- Office + WFH counts sum to total records found
- Meal counts match what was entered (only `true` values count, `false`/`null` do not)
- Team breakdown lists each team with correct member count and per-meal totals
- Teams with no records for the date do not appear in breakdown
- Records with no `teamId` are excluded from team breakdown but included in totals and location split
- If a schedule exists for the date with an `occasionName`, it appears in the header line

**Edge cases:**
- Date with no records → "No meal records found for **YYYY-MM-DD**."
- Invalid date format → "Invalid date format. Use YYYY-MM-DD."
- Non-admin, non-logistics user → "Only admins and logistics members can view headcount."

**Response visibility:**
- Confirm the message is public (visible to the channel), not ephemeral

---