### PR TITLE
Feature: Implementation of Daily Participation View of all/scoped employees with WFH Over-Limit Tracking for Admin/lead

### DIFF
--- a/meal-planner-task2/backend/src/commands/participation.ts
+++ b/meal-planner-task2/backend/src/commands/participation.ts
@@ -1,0 +1,61 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { getParticipation } from '../services/participationService.js'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export async function handleParticipation(req: AuthRequest, res: Response): Promise<void> {
+  const role = req.user!.role
+  if (role !== 'ADMIN' && role !== 'LEAD') {
+    res.json({ type: 4, data: { content: 'Only admins and leads can view participation.', flags: 64 } })
+    return
+  }
+
+  let date: string
+  if (req.user!.platform === 'google') {
+    date = (req.body?.message?.argumentText as string ?? '').trim()
+  } else {
+    const options: Array<{ name: string; value: string }> = req.body.data?.options ?? []
+    date = options.find(o => o.name === 'date')?.value ?? ''
+  }
+
+  if (!DATE_RE.test(date)) {
+    res.json({ type: 4, data: { content: 'Invalid date format. Use YYYY-MM-DD.', flags: 64 } })
+    return
+  }
+
+  // LEAD is scoped to their own team; ADMIN sees all
+  const teamId = role === 'LEAD' ? req.user!.teamId : undefined
+
+  const data = await getParticipation(date, teamId)
+
+  if (data.employees.length === 0) {
+    res.json({ type: 4, data: { content: `No participation data found for **${date}**.`, flags: 64 } })
+    return
+  }
+
+  const scopeLabel = role === 'LEAD' ? ' *(your team)*' : ''
+  const header     = `👥 **Participation — ${date}**${scopeLabel}\n`
+
+  const lines = data.employees.map(e => {
+    const wfh  = e.workFromHome ? '🏠' : '🏢'
+    const meals = [
+      e.meals.lunch          === true  ? 'L:✅' : e.meals.lunch          === false ? 'L:❌' : '',
+      e.meals.snacks         === true  ? 'S:✅' : e.meals.snacks         === false ? 'S:❌' : '',
+      e.meals.iftar          === true  ? 'I:✅' : e.meals.iftar          === false ? 'I:❌' : '',
+      e.meals.eventDinner    === true  ? 'ED:✅': e.meals.eventDinner    === false ? 'ED:❌': '',
+      e.meals.optionalDinner === true  ? 'OD:✅': e.meals.optionalDinner === false ? 'OD:❌': '',
+    ].filter(Boolean).join('  ') || '—'
+
+    const team = e.teamName ? ` *[${e.teamName}]*` : ''
+    return `${wfh} **${e.name}**${team} — ${meals}  WFH/mo: ${e.wfhCount}`
+  })
+
+  res.json({
+    type: 4,
+    data: {
+      content: header + lines.join('\n'),
+      flags: 64,
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -12,6 +12,7 @@ import { handleListWfhPeriods } from '../commands/listWfhPeriods.js'
 import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 import { handleHeadcount }       from '../commands/headcount.js'
+import { handleParticipation }   from '../commands/participation.js'
 
 /**
  * Entry point for all Discord slash commands.
@@ -37,6 +38,7 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
         case 'update-wfh-period': await handleUpdateWfhPeriod(req, res); return
         case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
         case 'headcount':         await handleHeadcount(req, res);       return
+        case 'participation':     await handleParticipation(req, res);   return
         default:
           res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
           return

--- a/meal-planner-task2/backend/src/controllers/googleController.ts
+++ b/meal-planner-task2/backend/src/controllers/googleController.ts
@@ -12,6 +12,7 @@ import { handleListWfhPeriods } from '../commands/listWfhPeriods.js'
 import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 import { handleHeadcount }       from '../commands/headcount.js'
+import { handleParticipation }   from '../commands/participation.js'
 
 /**
  * Entry point for all Google Chat slash commands.
@@ -47,6 +48,7 @@ export const handleGoogleInteraction = async (req: AuthRequest, res: Response): 
       case 'update-wfh-period': await handleUpdateWfhPeriod(req, res); return
       case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
       case 'headcount':         await handleHeadcount(req, res);       return
+      case 'participation':     await handleParticipation(req, res);   return
       default:
         res.json({ text: `Unknown command \`/${commandName}\`.` })
     }

--- a/meal-planner-task2/backend/src/services/participationService.ts
+++ b/meal-planner-task2/backend/src/services/participationService.ts
@@ -1,0 +1,108 @@
+import { QueryCommand, BatchGetCommand, GetCommand } from '@aws-sdk/lib-dynamodb'
+import { dynamo, TABLES } from '../config/dynamoClient.js'
+import type { UserItem, MealRecordItem, TeamItem, DailyParticipationData } from '../types/index.js'
+
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size))
+  return chunks
+}
+
+async function batchGetProfiles(discordIds: string[]): Promise<UserItem[]> {
+  const profiles: UserItem[] = []
+  for (const chunk of chunkArray(discordIds, 100)) {
+    const result = await dynamo.send(new BatchGetCommand({
+      RequestItems: {
+        [TABLES.MAIN]: {
+          Keys: chunk.map(id => ({ PK: `USER#${id}`, SK: 'PROFILE' })),
+        },
+      },
+    }))
+    profiles.push(...((result.Responses?.[TABLES.MAIN] ?? []) as UserItem[]))
+  }
+  return profiles
+}
+
+async function batchGetRecords(discordIds: string[], date: string): Promise<MealRecordItem[]> {
+  const records: MealRecordItem[] = []
+  for (const chunk of chunkArray(discordIds, 100)) {
+    const result = await dynamo.send(new BatchGetCommand({
+      RequestItems: {
+        [TABLES.MAIN]: {
+          Keys: chunk.map(id => ({ PK: `USER#${id}`, SK: `RECORD#${date}` })),
+        },
+      },
+    }))
+    records.push(...((result.Responses?.[TABLES.MAIN] ?? []) as MealRecordItem[]))
+  }
+  return records
+}
+
+/**
+ * Returns per-employee participation for a date.
+ * - teamId provided → scoped to that team's members (LEAD view)
+ * - teamId omitted  → all active users (ADMIN view)
+ */
+export async function getParticipation(
+  date:    string,
+  teamId?: string,
+): Promise<DailyParticipationData> {
+  let discordIds: string[]
+
+  if (teamId) {
+    // LEAD path: get member list from team item
+    const teamResult = await dynamo.send(new GetCommand({
+      TableName: TABLES.MAIN,
+      Key: { PK: 'TEAM', SK: teamId },
+    }))
+    const team = teamResult.Item as TeamItem | undefined
+    discordIds = team?.memberIds ? [...team.memberIds] : []
+  } else {
+    // ADMIN path: all active users via GSI
+    const gsiResult = await dynamo.send(new QueryCommand({
+      TableName:                 TABLES.MAIN,
+      IndexName:                 'status-email-index',
+      KeyConditionExpression:    '#status = :active',
+      ExpressionAttributeNames:  { '#status': 'status' },
+      ExpressionAttributeValues: { ':active': 'ACTIVE' },
+    }))
+    discordIds = ((gsiResult.Items ?? []) as UserItem[]).map(u => u.discordId)
+  }
+
+  if (!discordIds.length) {
+    return { date, employees: [] }
+  }
+
+  const [profiles, records] = await Promise.all([
+    batchGetProfiles(discordIds),
+    batchGetRecords(discordIds, date),
+  ])
+
+  const profileMap = new Map(profiles.map(p => [p.discordId, p]))
+  const recordMap  = new Map(records.map(r => [r.discordId, r]))
+
+  const employees = discordIds
+    .map(id => {
+      const profile = profileMap.get(id)
+      const record  = recordMap.get(id)
+      if (!profile) return null
+      return {
+        discordId:    id,
+        name:         profile.name,
+        teamName:     profile.teamName ?? null,
+        workFromHome: record?.workFromHome ?? false,
+        wfhCount:     profile.wfhCount,
+        meals: {
+          lunch:          record?.lunch          ?? null,
+          snacks:         record?.snacks         ?? null,
+          iftar:          record?.iftar          ?? null,
+          eventDinner:    record?.eventDinner    ?? null,
+          optionalDinner: record?.optionalDinner ?? null,
+        },
+      }
+    })
+    .filter((e): e is NonNullable<typeof e> => e !== null)
+    .sort((a, b) => (a.teamName ?? '').localeCompare(b.teamName ?? '') || a.name.localeCompare(b.name))
+
+  return { date, employees }
+}

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -204,6 +204,20 @@ const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
     ],
   },
 
+  // ── F8: Participation View ────────────────────────────────────────────────
+  {
+    name: 'participation',
+    description: 'View per-employee meal participation for a date (Admin/Lead only)',
+    options: [
+      {
+        name: 'date',
+        description: 'Date in YYYY-MM-DD format',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    ],
+  },
+
   // ── F7: Headcount ─────────────────────────────────────────────────────────
   {
     name: 'headcount',


### PR DESCRIPTION
- Closes #42 

## What does this PR do?

Adds the `/participation` slash command for ADMIN and LEAD roles on both Discord and Google Chat. Returns an ephemeral per-employee breakdown for a given date showing each person's meal opt-in/out status, WFH flag, and monthly WFH count. LEAD view is automatically scoped to their own team; ADMIN sees all employees across all teams.

## Type of Change

- [x] New feature

## What was changed

- **`participationService.ts`** — `getParticipation(date, teamId?)`: LEAD path fetches team `memberIds` from the team item then batch-gets profiles and records in parallel; ADMIN path queries all active users via `status-email-index` GSI then batch-gets profiles and records in parallel; both paths join by `discordId` and sort by `teamName` then `name`
- **`participation.ts`** — ADMIN/LEAD-only handler, required `date` arg, derives `teamId` scope from `req.user` (LEAD gets own `teamId`, ADMIN gets `undefined`), ephemeral response (`flags: 64`), formats per-employee rows with name, team label, meal indicators, WFH icon, and monthly WFH count
- **`discordController.ts` / `googleController.ts`** — route `participation` command
- **`deploy-commands.ts`** — register `/participation` with required `date` string option

## Changelog

Feature: Admins and leads can now run `/participation` to see a per-employee meal and WFH breakdown for any date; leads are automatically scoped to their own team


## Test Resources
**Invitation to Discord Server:** https://discord.gg/YUubbepy
**Google Chat Space URL:** https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint:** https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table:** https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2



## How to Test

**Affected workflows:**
- Admin full-company daily participation overview
- Lead team-scoped daily participation view

### Specific checks:

**Admin view:**
- `/participation date:2026-03-24` → ephemeral list of all employees across all three teams, sorted by team then name
- Employees with no record for the date still appear (profile exists) with all meals shown as omitted and `🏢` WFH flag

**Lead view**
- `/participation date:2026-03-24` → only Team members shown; header includes lead's teamId
- A lead with no `teamId` set → "No participation data found for **YYYY-MM-DD**."

**Meal indicators:**
- `lunch: true` → `L:✅`
- `lunch: false` → `L:❌`
- `lunch: null` → field omitted entirely
- WFH `true` → `🏠`, `false` → `🏢`

**Monthly WFH count:**
- `WFH/mo: N` reflects the `wfhCount` on the user profile which is number of WFH taken in this month

**Authorization:**
- EMPLOYEE or LOGISTICS role → "Only admins and leads can view participation."

**Validation:**
- Invalid date format → "Invalid date format. Use YYYY-MM-DD."
- Valid date with no records and no profiles matched → "No participation data found for **YYYY-MM-DD**."

**Google Chat:**
- `/participation 2026-03-24` → same scoping and output as Discord

**Response visibility:**
- Confirm message is ephemeral (only visible to the invoking user)

