### PR TITLE
Feature: View All/Team Members List and their 7-day schedules meal records for Admin/Leads

### DIFF
--- a/meal-planner-task2/backend/src/commands/employeeSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/employeeSchedule.ts
@@ -1,0 +1,83 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { getMySchedule } from '../services/mealService.js'
+import { isTeamMember } from '../services/teamService.js'
+import type { ScheduleDay, MealScheduleItem } from '../types/index.js'
+
+const MEALS: Array<{ key: keyof MealScheduleItem; label: string }> = [
+  { key: 'lunchEnabled',          label: 'L' },
+  { key: 'snacksEnabled',         label: 'S' },
+  { key: 'iftarEnabled',          label: 'I' },
+  { key: 'eventDinnerEnabled',    label: 'ED' },
+  { key: 'optionalDinnerEnabled', label: 'OD' },
+]
+
+const MEAL_RECORD_KEYS = ['lunch', 'snacks', 'iftar', 'eventDinner', 'optionalDinner'] as const
+
+function formatDay(day: ScheduleDay): string {
+  const date   = new Date(day.date + 'T00:00:00Z')
+  const label  = date.toLocaleDateString('en-GB', { weekday: 'short', day: '2-digit', month: 'short', timeZone: 'UTC' })
+  const prefix = day.isToday ? '**Today** ' : ''
+
+  const mealCols = MEALS.map((m, i) => {
+    const enabled = day.schedule?.[m.key] as boolean | undefined
+    if (!enabled) return '➖'
+    const chosen = day.record?.[MEAL_RECORD_KEYS[i]]
+    if (chosen === true)  return `${m.label}:✅`
+    if (chosen === false) return `${m.label}:❌`
+    return `${m.label}:⬜`
+  }).join('  ')
+
+  const wfh = (day.record?.workFromHome || day.globalWFH) ? '  🏠' : ''
+  return `${prefix}${label}  ${mealCols}${wfh}`
+}
+
+export async function handleEmployeeSchedule(req: AuthRequest, res: Response): Promise<void> {
+  const user = req.user!
+
+  if (user.role !== 'LEAD' && user.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only leads and admins can view a team member\'s schedule.', flags: 64 } })
+    return
+  }
+
+  // Parse target discordId
+  let targetId: string
+  if (user.platform === 'google') {
+    targetId = (req.body?.message?.argumentText as string ?? '').trim()
+  } else {
+    // Discord User option — value is the selected user's Discord ID
+    const options: Array<{ name: string; value: string }> = req.body.data?.options ?? []
+    targetId = options.find(o => o.name === 'user')?.value ?? ''
+  }
+
+  if (!targetId) {
+    res.json({ type: 4, data: { content: 'Please specify a team member.', flags: 64 } })
+    return
+  }
+
+  // LEAD must verify the target belongs to their team; ADMIN has no restriction
+  if (user.role === 'LEAD') {
+    if (!user.teamId) {
+      res.json({ type: 4, data: { content: 'You are not assigned to a team.', flags: 64 } })
+      return
+    }
+    const member = await isTeamMember(user.teamId, targetId)
+    if (!member) {
+      res.json({ type: 4, data: { content: 'That user is not in your team.', flags: 64 } })
+      return
+    }
+  }
+
+  const days = await getMySchedule(targetId)
+
+  const lines  = days.map(formatDay)
+  const legend = '*✅ opted in  ❌ opted out  ⬜ not set  ➖ not offered  🏠 WFH*'
+
+  res.json({
+    type: 4,
+    data: {
+      content: `📅 **Schedule for <@${targetId}>**\n\n${lines.join('\n')}\n\n${legend}`,
+      flags: 64,
+    },
+  })
+}

--- a/meal-planner-task2/backend/src/commands/employeeSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/employeeSchedule.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express'
 import { AuthRequest } from '../types/index.js'
 import { getMySchedule } from '../services/mealService.js'
-import { isTeamMember } from '../services/teamService.js'
+import { isTeamMember, getUserByEmail } from '../services/teamService.js'
 import type { ScheduleDay, MealScheduleItem } from '../types/index.js'
 
 const MEALS: Array<{ key: keyof MealScheduleItem; label: string }> = [
@@ -43,16 +43,28 @@ export async function handleEmployeeSchedule(req: AuthRequest, res: Response): P
   // Parse target discordId
   let targetId: string
   if (user.platform === 'google') {
-    targetId = (req.body?.message?.argumentText as string ?? '').trim()
+    // Google Chat: extract email from @mention annotation
+    const annotations: any[] = req.body?.message?.annotations ?? []
+    const mention = annotations.find((a: any) => a.type === 'USER_MENTION')
+    const email: string | undefined = mention?.userMention?.user?.email
+    if (!email) {
+      res.json({ text: 'Please @mention a team member. Example: `/employee-schedule @Samin Yasar`' })
+      return
+    }
+    const profile = await getUserByEmail(email)
+    if (!profile) {
+      res.json({ text: `No active user found for the mentioned account.` })
+      return
+    }
+    targetId = profile.discordId
   } else {
     // Discord User option — value is the selected user's Discord ID
     const options: Array<{ name: string; value: string }> = req.body.data?.options ?? []
     targetId = options.find(o => o.name === 'user')?.value ?? ''
-  }
-
-  if (!targetId) {
-    res.json({ type: 4, data: { content: 'Please specify a team member.', flags: 64 } })
-    return
+    if (!targetId) {
+      res.json({ type: 4, data: { content: 'Please specify a team member.', flags: 64 } })
+      return
+    }
   }
 
   // LEAD must verify the target belongs to their team; ADMIN has no restriction

--- a/meal-planner-task2/backend/src/commands/teamMembers.ts
+++ b/meal-planner-task2/backend/src/commands/teamMembers.ts
@@ -1,0 +1,36 @@
+import { Response } from 'express'
+import { AuthRequest } from '../types/index.js'
+import { getTeamMembers } from '../services/teamService.js'
+
+export async function handleTeamMembers(req: AuthRequest, res: Response): Promise<void> {
+  const user = req.user!
+
+  if (user.role !== 'LEAD' && user.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only leads and admins can view team members.', flags: 64 } })
+    return
+  }
+
+  if (!user.teamId) {
+    res.json({ type: 4, data: { content: 'You are not assigned to a team.', flags: 64 } })
+    return
+  }
+
+  const { teamName, members } = await getTeamMembers(user.teamId)
+
+  if (!members.length) {
+    res.json({ type: 4, data: { content: `No members found in **${teamName}**.`, flags: 64 } })
+    return
+  }
+
+  const now   = new Date()
+  const month = now.toLocaleString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' })
+
+  const lines = members.map(m => {
+    const status = m.status === 'ACTIVE' ? '🟢' : '🔴'
+    return `${status} **${m.name}** — WFH this month: ${m.wfhCount}`
+  })
+
+  const content = `👥 **${teamName}** *(${members.length} member${members.length === 1 ? '' : 's'}) — ${month}*\n\n${lines.join('\n')}`
+
+  res.json({ type: 4, data: { content, flags: 64 } })
+}

--- a/meal-planner-task2/backend/src/commands/teamMembers.ts
+++ b/meal-planner-task2/backend/src/commands/teamMembers.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express'
 import { AuthRequest } from '../types/index.js'
-import { getTeamMembers } from '../services/teamService.js'
+import { getTeamMembers, getAllActiveMembers } from '../services/teamService.js'
+import type { TeamMemberView } from '../services/teamService.js'
 
 export async function handleTeamMembers(req: AuthRequest, res: Response): Promise<void> {
   const user = req.user!
@@ -10,6 +11,28 @@ export async function handleTeamMembers(req: AuthRequest, res: Response): Promis
     return
   }
 
+  const now   = new Date()
+  const month = now.toLocaleString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' })
+
+  if (user.role === 'ADMIN') {
+    // Admin sees all active employees grouped by team
+    const members = await getAllActiveMembers()
+    if (!members.length) {
+      res.json({ type: 4, data: { content: 'No active employees found.', flags: 64 } })
+      return
+    }
+
+    const lines = members.map(m => {
+      const status = m.status === 'ACTIVE' ? '🟢' : '🔴'
+      return `${status} **${m.name}** *[${m.teamName}]* — WFH this month: ${m.wfhCount}`
+    })
+
+    const content = `👥 **All Employees** *(${members.length} active) — ${month}*\n\n${lines.join('\n')}`
+    res.json({ type: 4, data: { content, flags: 64 } })
+    return
+  }
+
+  // LEAD sees only their own team
   if (!user.teamId) {
     res.json({ type: 4, data: { content: 'You are not assigned to a team.', flags: 64 } })
     return
@@ -22,15 +45,11 @@ export async function handleTeamMembers(req: AuthRequest, res: Response): Promis
     return
   }
 
-  const now   = new Date()
-  const month = now.toLocaleString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' })
-
-  const lines = members.map(m => {
+  const lines = members.map((m: TeamMemberView) => {
     const status = m.status === 'ACTIVE' ? '🟢' : '🔴'
     return `${status} **${m.name}** — WFH this month: ${m.wfhCount}`
   })
 
   const content = `👥 **${teamName}** *(${members.length} member${members.length === 1 ? '' : 's'}) — ${month}*\n\n${lines.join('\n')}`
-
   res.json({ type: 4, data: { content, flags: 64 } })
 }

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -13,6 +13,7 @@ import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 import { handleHeadcount }       from '../commands/headcount.js'
 import { handleParticipation }   from '../commands/participation.js'
+import { handleTeamMembers }     from '../commands/teamMembers.js'
 
 /**
  * Entry point for all Discord slash commands.
@@ -39,6 +40,7 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
         case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
         case 'headcount':         await handleHeadcount(req, res);       return
         case 'participation':     await handleParticipation(req, res);   return
+        case 'team-members':      await handleTeamMembers(req, res);     return
         default:
           res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
           return

--- a/meal-planner-task2/backend/src/controllers/discordController.ts
+++ b/meal-planner-task2/backend/src/controllers/discordController.ts
@@ -13,7 +13,8 @@ import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 import { handleHeadcount }       from '../commands/headcount.js'
 import { handleParticipation }   from '../commands/participation.js'
-import { handleTeamMembers }     from '../commands/teamMembers.js'
+import { handleTeamMembers }      from '../commands/teamMembers.js'
+import { handleEmployeeSchedule } from '../commands/employeeSchedule.js'
 
 /**
  * Entry point for all Discord slash commands.
@@ -40,7 +41,8 @@ export const handleInteraction = async (req: AuthRequest, res: Response): Promis
         case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
         case 'headcount':         await handleHeadcount(req, res);       return
         case 'participation':     await handleParticipation(req, res);   return
-        case 'team-members':      await handleTeamMembers(req, res);     return
+        case 'team-members':       await handleTeamMembers(req, res);      return
+        case 'employee-schedule':  await handleEmployeeSchedule(req, res); return
         default:
           res.json({ type: 4, data: { content: `Unknown command \`/${data?.name}\`.`, flags: 64 } })
           return

--- a/meal-planner-task2/backend/src/controllers/googleController.ts
+++ b/meal-planner-task2/backend/src/controllers/googleController.ts
@@ -13,6 +13,7 @@ import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 import { handleHeadcount }       from '../commands/headcount.js'
 import { handleParticipation }   from '../commands/participation.js'
+import { handleTeamMembers }     from '../commands/teamMembers.js'
 
 /**
  * Entry point for all Google Chat slash commands.
@@ -49,6 +50,7 @@ export const handleGoogleInteraction = async (req: AuthRequest, res: Response): 
       case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
       case 'headcount':         await handleHeadcount(req, res);       return
       case 'participation':     await handleParticipation(req, res);   return
+      case 'team-members':      await handleTeamMembers(req, res);     return
       default:
         res.json({ text: `Unknown command \`/${commandName}\`.` })
     }

--- a/meal-planner-task2/backend/src/controllers/googleController.ts
+++ b/meal-planner-task2/backend/src/controllers/googleController.ts
@@ -13,7 +13,8 @@ import { handleUpdateWfhPeriod } from '../commands/updateWfhPeriod.js'
 import { handleDeleteWfhPeriod } from '../commands/deleteWfhPeriod.js'
 import { handleHeadcount }       from '../commands/headcount.js'
 import { handleParticipation }   from '../commands/participation.js'
-import { handleTeamMembers }     from '../commands/teamMembers.js'
+import { handleTeamMembers }      from '../commands/teamMembers.js'
+import { handleEmployeeSchedule } from '../commands/employeeSchedule.js'
 
 /**
  * Entry point for all Google Chat slash commands.
@@ -50,7 +51,8 @@ export const handleGoogleInteraction = async (req: AuthRequest, res: Response): 
       case 'delete-wfh-period': await handleDeleteWfhPeriod(req, res); return
       case 'headcount':         await handleHeadcount(req, res);       return
       case 'participation':     await handleParticipation(req, res);   return
-      case 'team-members':      await handleTeamMembers(req, res);     return
+      case 'team-members':       await handleTeamMembers(req, res);      return
+      case 'employee-schedule':  await handleEmployeeSchedule(req, res); return
       default:
         res.json({ text: `Unknown command \`/${commandName}\`.` })
     }

--- a/meal-planner-task2/backend/src/services/teamService.ts
+++ b/meal-planner-task2/backend/src/services/teamService.ts
@@ -1,4 +1,4 @@
-import { GetCommand, BatchGetCommand } from '@aws-sdk/lib-dynamodb'
+import { GetCommand, BatchGetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import type { TeamItem, UserItem } from '../types/index.js'
 
@@ -57,6 +57,48 @@ export async function getTeamMembers(teamId: string): Promise<{
     .sort((a, b) => a.name.localeCompare(b.name))
 
   return { teamName: team.name, members }
+}
+
+/**
+ * Returns all active users for ADMIN view, sorted by teamName then name.
+ */
+export async function getAllActiveMembers(): Promise<TeamMemberView[]> {
+  const gsiResult = await dynamo.send(new QueryCommand({
+    TableName:                 TABLES.MAIN,
+    IndexName:                 'status-email-index',
+    KeyConditionExpression:    '#status = :active',
+    ExpressionAttributeNames:  { '#status': 'status' },
+    ExpressionAttributeValues: { ':active': 'ACTIVE' },
+  }))
+
+  const profiles = (gsiResult.Items ?? []) as UserItem[]
+
+  return profiles
+    .map(p => ({
+      discordId: p.discordId,
+      name:      p.name,
+      status:    p.status,
+      wfhCount:  p.wfhCount,
+      wfhMonth:  p.wfhMonth,
+      teamName:  p.teamName ?? '—',
+    }))
+    .sort((a, b) => a.teamName.localeCompare(b.teamName) || a.name.localeCompare(b.name))
+}
+
+/**
+ * Looks up a user profile by email via the status-email-index GSI.
+ * Returns the profile or undefined if not found.
+ */
+export async function getUserByEmail(email: string): Promise<UserItem | undefined> {
+  const result = await dynamo.send(new QueryCommand({
+    TableName:                 TABLES.MAIN,
+    IndexName:                 'status-email-index',
+    KeyConditionExpression:    '#status = :active AND email = :email',
+    ExpressionAttributeNames:  { '#status': 'status' },
+    ExpressionAttributeValues: { ':active': 'ACTIVE', ':email': email },
+    Limit: 1,
+  }))
+  return (result.Items?.[0]) as UserItem | undefined
 }
 
 /**

--- a/meal-planner-task2/backend/src/services/teamService.ts
+++ b/meal-planner-task2/backend/src/services/teamService.ts
@@ -1,0 +1,73 @@
+import { GetCommand, BatchGetCommand } from '@aws-sdk/lib-dynamodb'
+import { dynamo, TABLES } from '../config/dynamoClient.js'
+import type { TeamItem, UserItem } from '../types/index.js'
+
+export interface TeamMemberView {
+  discordId: string
+  name:      string
+  status:    string
+  wfhCount:  number
+  wfhMonth:  string
+  teamName:  string
+}
+
+/**
+ * Returns the team item and a roster of member profiles for a given teamId.
+ * Throws if the team does not exist or has no members.
+ */
+export async function getTeamMembers(teamId: string): Promise<{
+  teamName: string
+  members:  TeamMemberView[]
+}> {
+  const teamResult = await dynamo.send(new GetCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'TEAM', SK: teamId },
+  }))
+
+  const team = teamResult.Item as TeamItem | undefined
+  if (!team) throw new Error(`Team not found: ${teamId}`)
+
+  const memberIds = team.memberIds ? [...team.memberIds] : []
+  if (!memberIds.length) return { teamName: team.name, members: [] }
+
+  const chunks: string[][] = []
+  for (let i = 0; i < memberIds.length; i += 100) chunks.push(memberIds.slice(i, i + 100))
+
+  const profiles: UserItem[] = []
+  for (const chunk of chunks) {
+    const result = await dynamo.send(new BatchGetCommand({
+      RequestItems: {
+        [TABLES.MAIN]: {
+          Keys: chunk.map(id => ({ PK: `USER#${id}`, SK: 'PROFILE' })),
+        },
+      },
+    }))
+    profiles.push(...((result.Responses?.[TABLES.MAIN] ?? []) as UserItem[]))
+  }
+
+  const members: TeamMemberView[] = profiles
+    .map(p => ({
+      discordId: p.discordId,
+      name:      p.name,
+      status:    p.status,
+      wfhCount:  p.wfhCount,
+      wfhMonth:  p.wfhMonth,
+      teamName:  team.name,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return { teamName: team.name, members }
+}
+
+/**
+ * Verifies that targetDiscordId is a member of the given team.
+ * Returns true if the member belongs to the team.
+ */
+export async function isTeamMember(teamId: string, targetDiscordId: string): Promise<boolean> {
+  const teamResult = await dynamo.send(new GetCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'TEAM', SK: teamId },
+  }))
+  const team = teamResult.Item as TeamItem | undefined
+  return !!(team?.memberIds?.has(targetDiscordId))
+}

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -207,11 +207,11 @@ const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
   // ── F9: Team Lead Views ───────────────────────────────────────────────────
   {
     name: 'team-members',
-    description: 'View your team roster with WFH counts (Lead only)',
+    description: 'View team roster with WFH counts (Lead: own team, Admin: all)',
   },
   {
     name: 'employee-schedule',
-    description: "View a team member's 7-day meal schedule (Lead only)",
+    description: "View a team member's 7-day meal schedule (Lead: own team, Admin: any)",
     options: [
       {
         name: 'user',

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -204,6 +204,12 @@ const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
     ],
   },
 
+  // ── F9: Team Lead Views ───────────────────────────────────────────────────
+  {
+    name: 'team-members',
+    description: 'View your team roster with WFH counts (Lead only)',
+  },
+
   // ── F8: Participation View ────────────────────────────────────────────────
   {
     name: 'participation',

--- a/meal-planner-task2/discord-bot/src/deploy-commands.ts
+++ b/meal-planner-task2/discord-bot/src/deploy-commands.ts
@@ -209,6 +209,18 @@ const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
     name: 'team-members',
     description: 'View your team roster with WFH counts (Lead only)',
   },
+  {
+    name: 'employee-schedule',
+    description: "View a team member's 7-day meal schedule (Lead only)",
+    options: [
+      {
+        name: 'user',
+        description: 'Select the team member',
+        type: ApplicationCommandOptionType.User,
+        required: true,
+      },
+    ],
+  },
 
   // ── F8: Participation View ────────────────────────────────────────────────
   {


### PR DESCRIPTION

- Closes #43 

## What does this PR do?

Adds `/team-members` and `/employee-schedule` slash commands for LEAD and ADMIN roles on both Discord and Google Chat. Leads see their own team; admins see all employees without restriction.

## Type of Change

- [x] New feature

## What was changed

- **`teamService.ts`** — `getTeamMembers(teamId)`: fetches team item, batch-gets member profiles in chunks of 100, returns sorted roster; `getAllActiveMembers()`: queries all active users via `status-email-index` GSI, returns flat list sorted by teamName then name; `isTeamMember(teamId, discordId)`: membership guard used by `/employee-schedule`
- **`teamMembers.ts`** — LEAD/ADMIN handler; LEAD path calls `getTeamMembers` scoped to `req.user.teamId`; ADMIN path calls `getAllActiveMembers` and shows all employees with team label; both paths return ephemeral response with status icon and monthly WFH count per member
- **`employeeSchedule.ts`** — LEAD/ADMIN handler; parses a `@UserName` picker option; LEAD is gated by `isTeamMember` to reject cross-team access; ADMIN has no restriction; reuses `getMySchedule` and the same day-formatting logic as `/my-schedule`; response is ephemeral and mentions the target with `<@id>`
- **`discordController.ts` / `googleController.ts`** — route `team-members` and `employee-schedule`
- **`deploy-commands.ts`** — register `/team-members` (no options) and `/employee-schedule` with a required `User` option

## Changelog

Feature: Leads can now run `/team-members` to see their team roster with WFH counts, and `/employee-schedule` to view any team member's 7-day schedule; admins can use both commands without team restriction


## Test Resources
**Invitation to Discord Server:** https://discord.gg/YUubbepy
**Google Chat Space URL:** https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint:** https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table:** https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2


## How to Test

Affected workflows:
- Lead daily team oversight
- Admin company-wide member visibility

**`/team-members` — LEAD:**
- Returns ephemeral roster of own team members only, sorted by name
- Shows 🟢/🔴 In/active status icon and WFH count for current month per member
- Lead with no `teamId` set → "You are not assigned to a team."
- Team with no members → "No members found in **Team Name**."

**`/team-members` — ADMIN:**
- Returns all active employees across all teams, sorted by team name then name
- Each row shows team label in brackets: `🟢 Name [Team Alpha] — WFH this month: N`
- No active employees → "No active employees found."

**`/employee-schedule` — LEAD:**
- Returns ephemeral 7-day schedule for a team member in their own team
- Attempting a member from another team → "That user is not in your team."
- Lead with no `teamId` → "You are not assigned to a team."

**`/employee-schedule` — ADMIN:**
- Can view any employee's schedule with no team restriction
- Response mentions the target user with `<@discordId>`

**Both commands:**
- EMPLOYEE or LOGISTICS role → "Only leads and admins can view team members." / "Only leads and admins can view a team member's schedule."
- No user specified on `/employee-schedule` → "Please specify a team member."

**Usage in Discord:**
- `/team-members` → scoped correctly by role
- `/employee-schedule {@Name}` → correct schedule returned

**Usage in Google Chat:**
- `/team-members` → scoped correctly by role same as discord
- `/employee-schedule {@Name}` → correct schedule returned 


**Response visibility:**
- Confirm all responses are ephemeral