### PR TITLE
Feature: Automated cron jobs — meal record creation at night, send headcount report at morning, and global WFH enforcement at cron

### DIFF
--- a/meal-planner-task2/backend/scripts/syncTeams.ts
+++ b/meal-planner-task2/backend/scripts/syncTeams.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse } from 'yaml'
-import { PutCommand } from '@aws-sdk/lib-dynamodb'
+import { UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../src/config/dynamoClient.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -26,18 +26,14 @@ async function syncTeams() {
   const now = new Date().toISOString()
 
   for (const team of teams) {
-    await dynamo.send(new PutCommand({
-      TableName: TABLES.MAIN,
-      Item: {
-        PK:        'TEAM',
-        SK:        team.teamId,
-        teamId:    team.teamId,
-        name:      team.name,
-        leadId:    team.leadId,
-        // memberIds is not set here — syncUsers.ts populates it via ADD
-        createdAt: now,
-        updatedAt: now,
-      },
+    await dynamo.send(new UpdateCommand({
+      TableName:                 TABLES.MAIN,
+      Key:                       { PK: 'TEAM', SK: team.teamId },
+      // memberIds is not set here — syncUsers.ts populates it via ADD
+      // createdAt uses if_not_exists to preserve the original timestamp on re-syncs
+      UpdateExpression:          'SET teamId = :teamId, #name = :name, leadId = :leadId, updatedAt = :now, createdAt = if_not_exists(createdAt, :now)',
+      ExpressionAttributeNames:  { '#name': 'name' },
+      ExpressionAttributeValues: { ':teamId': team.teamId, ':name': team.name, ':leadId': team.leadId, ':now': now },
     }))
 
     console.log(`  ✓ ${team.teamId}  (${team.name})  lead: ${team.leadId}`)

--- a/meal-planner-task2/backend/scripts/syncUsers.ts
+++ b/meal-planner-task2/backend/scripts/syncUsers.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse } from 'yaml'
-import { PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../src/config/dynamoClient.js'
 import type { Role, UserStatus } from '../src/types/index.js'
 
@@ -52,22 +52,24 @@ async function syncUsers() {
     const teamName = user.teamId ? (teamMap.get(user.teamId) ?? undefined) : undefined
 
     // ── Upsert UserProfile ─────────────────────────────────────────────────
-    await dynamo.send(new PutCommand({
-      TableName: TABLES.MAIN,
-      Item: {
-        PK:        `USER#${user.discordId}`,
-        SK:        'PROFILE',
-        discordId: user.discordId,
-        name:      user.name,
-        email:     user.email,
-        role:      user.role,
-        status:    user.status,
-        teamId:    user.teamId ?? undefined,
-        teamName:  teamName    ?? undefined,
-        wfhCount:  0,
-        wfhMonth,
-        createdAt: now,
-        updatedAt: now,
+    // Always update mutable fields (name, email, role, status, team).
+    // wfhCount/wfhMonth and createdAt use if_not_exists to preserve existing values on re-sync.
+    await dynamo.send(new UpdateCommand({
+      TableName:                 TABLES.MAIN,
+      Key:                       { PK: `USER#${user.discordId}`, SK: 'PROFILE' },
+      UpdateExpression:          'SET discordId = :discordId, #name = :name, email = :email, #role = :role, #status = :status, teamId = :teamId, teamName = :teamName, updatedAt = :now, wfhCount = if_not_exists(wfhCount, :zero), wfhMonth = if_not_exists(wfhMonth, :wfhMonth), createdAt = if_not_exists(createdAt, :now)',
+      ExpressionAttributeNames:  { '#name': 'name', '#role': 'role', '#status': 'status' },
+      ExpressionAttributeValues: {
+        ':discordId': user.discordId,
+        ':name':      user.name,
+        ':email':     user.email,
+        ':role':      user.role,
+        ':status':    user.status,
+        ':teamId':    user.teamId  ?? null,
+        ':teamName':  teamName     ?? null,
+        ':zero':      0,
+        ':wfhMonth':  wfhMonth,
+        ':now':       now,
       },
     }))
 

--- a/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
+++ b/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
@@ -21,6 +21,17 @@ function opt<T>(options: DiscordOption[], name: string): T | undefined {
   return found !== undefined ? (found.value as T) : undefined
 }
 
+/** 3-state token parser for Google Chat text commands.
+ *  `token`  → true  (opted in)
+ *  `-token` → false (explicit opt-out)
+ *  absent   → undefined (carry-forward / not specified)
+ */
+function parseToken(tokens: string[], name: string): boolean | undefined {
+  if (tokens.includes(name))       return true
+  if (tokens.includes(`-${name}`)) return false
+  return undefined
+}
+
 export async function parseMealOptions(req: AuthRequest): Promise<MealUpdateData> {
   if (req.user!.platform === 'google') {
     const argText = (req.body?.message?.argumentText as string ?? '').trim()
@@ -40,12 +51,12 @@ export async function parseMealOptions(req: AuthRequest): Promise<MealUpdateData
 
     return {
       date,
-      lunch:          schedule.lunchEnabled          ? (tokens.includes('lunch')          ? true : false) : null,
-      snacks:         schedule.snacksEnabled         ? (tokens.includes('snacks')         ? true : false) : null,
-      iftar:          schedule.iftarEnabled          ? (tokens.includes('iftar')          ? true : false) : null,
-      eventDinner:    schedule.eventDinnerEnabled    ? (tokens.includes('eventdinner')    ? true : false) : null,
-      optionalDinner: schedule.optionalDinnerEnabled ? (tokens.includes('optionaldinner') ? true : false) : null,
-      workFromHome:   tokens.includes('wfh'),
+      lunch:          schedule.lunchEnabled          ? parseToken(tokens, 'lunch')          : null,
+      snacks:         schedule.snacksEnabled         ? parseToken(tokens, 'snacks')         : null,
+      iftar:          schedule.iftarEnabled          ? parseToken(tokens, 'iftar')          : null,
+      eventDinner:    schedule.eventDinnerEnabled    ? parseToken(tokens, 'eventdinner')    : null,
+      optionalDinner: schedule.optionalDinnerEnabled ? parseToken(tokens, 'optionaldinner') : null,
+      workFromHome:   parseToken(tokens, 'wfh'),
     }
   }
 

--- a/meal-planner-task2/backend/src/commands/_proxyHelpers.ts
+++ b/meal-planner-task2/backend/src/commands/_proxyHelpers.ts
@@ -21,6 +21,17 @@ function opt<T>(options: DiscordOption[], name: string): T | undefined {
   return found !== undefined ? (found.value as T) : undefined
 }
 
+/** 3-state token parser for Google Chat text commands.
+ *  `token`  → true  (opted in)
+ *  `-token` → false (explicit opt-out)
+ *  absent   → undefined (carry-forward / not specified)
+ */
+function parseToken(tokens: string[], name: string): boolean | undefined {
+  if (tokens.includes(name))       return true
+  if (tokens.includes(`-${name}`)) return false
+  return undefined
+}
+
 /**
  * Resolves the target discordId from the request.
  * Discord: reads the `user` option (User picker → Discord ID).
@@ -81,12 +92,12 @@ export async function parseProxyMealOptions(req: AuthRequest): Promise<MealUpdat
     // Disabled meals: null (cron also ignores them, no point opting out of something not offered)
     return {
       date,
-      lunch:          schedule.lunchEnabled          ? (tokens.includes('lunch')          ? true : false) : null,
-      snacks:         schedule.snacksEnabled         ? (tokens.includes('snacks')         ? true : false) : null,
-      iftar:          schedule.iftarEnabled          ? (tokens.includes('iftar')          ? true : false) : null,
-      eventDinner:    schedule.eventDinnerEnabled    ? (tokens.includes('eventdinner')    ? true : false) : null,
-      optionalDinner: schedule.optionalDinnerEnabled ? (tokens.includes('optionaldinner') ? true : false) : null,
-      workFromHome:   tokens.includes('wfh'),
+      lunch:          schedule.lunchEnabled          ? parseToken(tokens, 'lunch')          : null,
+      snacks:         schedule.snacksEnabled         ? parseToken(tokens, 'snacks')         : null,
+      iftar:          schedule.iftarEnabled          ? parseToken(tokens, 'iftar')          : null,
+      eventDinner:    schedule.eventDinnerEnabled    ? parseToken(tokens, 'eventdinner')    : null,
+      optionalDinner: schedule.optionalDinnerEnabled ? parseToken(tokens, 'optionaldinner') : null,
+      workFromHome:   parseToken(tokens, 'wfh'),
     }
   }
 

--- a/meal-planner-task2/backend/src/commands/headcount.ts
+++ b/meal-planner-task2/backend/src/commands/headcount.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express'
 import { AuthRequest } from '../types/index.js'
-import { getHeadcount } from '../services/headcountService.js'
+import { getHeadcount, formatHeadcountMessage } from '../services/headcountService.js'
 import { getTodayString } from '../utils/dateHelpers.js'
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
@@ -26,43 +26,13 @@ export async function handleHeadcount(req: AuthRequest, res: Response): Promise<
     return
   }
 
-  const data = await getHeadcount(date)
+  const data    = await getHeadcount(date)
+  const content = formatHeadcountMessage(data)
 
-  if (data.overallTotal === 0) {
+  if (!content) {
     res.json({ type: 4, data: { content: `No meal records found for **${date}**.` } })
     return
   }
 
-  const occasionLine = data.occasionName ? ` — *${data.occasionName}*` : ''
-  const { mealTotals: m, workLocationSplit: w } = data
-
-  const mealLine = [
-    m.lunch          > 0 && `🍱 Lunch: **${m.lunch}**`,
-    m.snacks         > 0 && `🍪 Snacks: **${m.snacks}**`,
-    m.iftar          > 0 && `🌙 Iftar: **${m.iftar}**`,
-    m.eventDinner    > 0 && `🍽️ Event Dinner: **${m.eventDinner}**`,
-    m.optionalDinner > 0 && `🥘 Optional Dinner: **${m.optionalDinner}**`,
-  ].filter(Boolean).join('  ') || 'No meals opted in.'
-
-  const teamLines = data.teamBreakdown.map(t => {
-    const meals = [
-      t.lunch          > 0 && `L:${t.lunch}`,
-      t.snacks         > 0 && `S:${t.snacks}`,
-      t.iftar          > 0 && `I:${t.iftar}`,
-      t.eventDinner    > 0 && `ED:${t.eventDinner}`,
-      t.optionalDinner > 0 && `OD:${t.optionalDinner}`,
-    ].filter(Boolean).join(' ') || 'none'
-    return `  **${t.teamName}** (${t.totalMembers}) — ${meals}`
-  })
-
-  const lines = [
-    `📊 **Headcount — ${date}**${occasionLine}`,
-    ``,
-    `🏢 Office: **${w.office}**  🏠 WFH: **${w.wfh}**  👥 Total: **${data.overallTotal}**`,
-    ``,
-    mealLine,
-    teamLines.length > 0 ? `\n**By team:**\n${teamLines.join('\n')}` : '',
-  ].filter(s => s !== '').join('\n')
-
-  res.json({ type: 4, data: { content: lines } })
+  res.json({ type: 4, data: { content } })
 }

--- a/meal-planner-task2/backend/src/jobs/cronLambda.ts
+++ b/meal-planner-task2/backend/src/jobs/cronLambda.ts
@@ -2,10 +2,12 @@ import 'dotenv/config'
 import { QueryCommand, BatchGetCommand, BatchWriteCommand, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import {
+  getTodayString,
   getTomorrowString,
   isWeekend,
 } from '../utils/dateHelpers.js'
 import { writeAuditLog } from '../services/auditService.js'
+import { getHeadcount, formatHeadcountMessage } from '../services/headcountService.js'
 import type { UserItem, MealRecordItem, MealScheduleItem } from '../types/index.js'
 
 const DEFAULT_SCHEDULE = {
@@ -170,6 +172,11 @@ async function createRecords(): Promise<void> {
   const total = noRecord.length + filledCount
   console.log(`Done. ${total} records written for ${date}.`)
 
+  await postWebhook(
+    `🌙 **Nightly records created — ${date}**\n` +
+    `✅ New: **${noRecord.length}**  📝 Filled: **${filledCount}**  👥 Total active users: **${discordIds.length}**`
+  )
+
   await writeAuditLog({
     actorDiscordId: 'SYSTEM',
     actorName:      'SYSTEM',
@@ -187,93 +194,17 @@ async function createRecords(): Promise<void> {
  * and posts a report to the configured Discord channel.
  */
 async function sendHeadcountReport(): Promise<void> {
-  const webhookUrl = process.env.DISCORD_WEBHOOK_URL
-  if (!webhookUrl) {
-    console.error('DISCORD_WEBHOOK_URL not set — skipping report.')
+  const date = getTodayString()
+  const data = await getHeadcount(date)
+
+  const content = formatHeadcountMessage(data)
+  if (!content) {
+    console.log(`No meal records found for ${date} — skipping report.`)
     return
   }
 
-  // Today's date string
-  const today = new Date()
-  const date  = today.toISOString().slice(0, 10)
-
-  // Get all active users via GSI
-  const gsiResult = await dynamo.send(new QueryCommand({
-    TableName:                 TABLES.MAIN,
-    IndexName:                 'status-email-index',
-    KeyConditionExpression:    '#status = :active',
-    ExpressionAttributeNames:  { '#status': 'status' },
-    ExpressionAttributeValues: { ':active': 'ACTIVE' },
-  }))
-  const activeUsers = (gsiResult.Items ?? []) as UserItem[]
-  if (!activeUsers.length) {
-    console.log('No active users — skipping report.')
-    return
-  }
-
-  const discordIds = activeUsers.map(u => u.discordId)
-
-  // BatchGet today's meal records for all active users (chunks of 100)
-  const records: MealRecordItem[] = []
-  const chunks = chunkArray(discordIds, 100)
-
-  for (const chunk of chunks) {
-    const batchResult = await dynamo.send(new BatchGetCommand({
-      RequestItems: {
-        [TABLES.MAIN]: {
-          Keys: chunk.map(id => ({ PK: `USER#${id}`, SK: `RECORD#${date}` })),
-        },
-      },
-    }))
-    records.push(...((batchResult.Responses?.[TABLES.MAIN] ?? []) as MealRecordItem[]))
-  }
-
-  // Aggregate counts
-  const office = records.filter(r => !r.workFromHome).length
-  const wfh    = records.filter(r => r.workFromHome).length
-  const lunch          = records.filter(r => r.lunch === true).length
-  const snacks         = records.filter(r => r.snacks === true).length
-  const iftar          = records.filter(r => r.iftar === true).length
-  const eventDinner    = records.filter(r => r.eventDinner === true).length
-  const optionalDinner = records.filter(r => r.optionalDinner === true).length
-
-  // Team breakdown
-  const teamMap = new Map<string, { name: string; lunch: number; snacks: number }>()
-  for (const r of records) {
-    if (!r.teamId) continue
-    const entry = teamMap.get(r.teamId) ?? { name: r.teamName ?? r.teamId, lunch: 0, snacks: 0 }
-    if (r.lunch  === true) entry.lunch++
-    if (r.snacks === true) entry.snacks++
-    teamMap.set(r.teamId, entry)
-  }
-
-  const teamLines = [...teamMap.values()]
-    .map(t => `  ${t.name}: Lunch ${t.lunch} | Snacks ${t.snacks}`)
-    .join('\n')
-
-  const message = [
-    `📊 **Daily Headcount — ${date}**`,
-    ``,
-    `🏢 Office: **${office}** | 🏠 WFH: **${wfh}**`,
-    ``,
-    `**Meal Counts:**`,
-    `🍱 Lunch: ${lunch}  🍪 Snacks: ${snacks}  🌙 Iftar: ${iftar}  🍽️ Event Dinner: ${eventDinner}  🥘 Optional Dinner: ${optionalDinner}`,
-    teamLines ? `\n**By Team:**\n${teamLines}` : '',
-  ].filter(Boolean).join('\n')
-
-  // Post to Discord via webhook
-  const response = await fetch(webhookUrl, {
-    method:  'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body:    JSON.stringify({ content: message }),
-  })
-
-  if (!response.ok) {
-    const body = await response.text()
-    console.error(`Failed to post headcount report: ${response.status} ${body}`)
-  } else {
-    console.log('Headcount report posted successfully.')
-  }
+  await postWebhook(content)
+  console.log('Headcount report posted successfully.')
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -282,4 +213,21 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
   const chunks: T[][] = []
   for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size))
   return chunks
+}
+
+async function postWebhook(content: string): Promise<void> {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL
+  if (!webhookUrl) {
+    console.error('DISCORD_WEBHOOK_URL not set — skipping webhook post.')
+    return
+  }
+  const response = await fetch(webhookUrl, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify({ content }),
+  })
+  if (!response.ok) {
+    const body = await response.text()
+    console.error(`Webhook post failed: ${response.status} ${body}`)
+  }
 }

--- a/meal-planner-task2/backend/src/jobs/cronLambda.ts
+++ b/meal-planner-task2/backend/src/jobs/cronLambda.ts
@@ -216,18 +216,37 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
 }
 
 async function postWebhook(content: string): Promise<void> {
-  const webhookUrl = process.env.DISCORD_WEBHOOK_URL
-  if (!webhookUrl) {
-    console.error('DISCORD_WEBHOOK_URL not set — skipping webhook post.')
-    return
+  const posts: Promise<void>[] = []
+
+  const discordUrl = process.env.DISCORD_WEBHOOK_URL
+  if (discordUrl) {
+    posts.push(
+      fetch(discordUrl, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ content }),
+      }).then(async r => {
+        if (!r.ok) console.error(`Discord webhook failed: ${r.status} ${await r.text()}`)
+      })
+    )
+  } else {
+    console.warn('DISCORD_WEBHOOK_URL not set — skipping Discord post.')
   }
-  const response = await fetch(webhookUrl, {
-    method:  'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body:    JSON.stringify({ content }),
-  })
-  if (!response.ok) {
-    const body = await response.text()
-    console.error(`Webhook post failed: ${response.status} ${body}`)
+
+  const googleUrl = process.env.GOOGLE_CHAT_WEBHOOK_URL
+  if (googleUrl) {
+    posts.push(
+      fetch(googleUrl, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ text: content }),
+      }).then(async r => {
+        if (!r.ok) console.error(`Google Chat webhook failed: ${r.status} ${await r.text()}`)
+      })
+    )
+  } else {
+    console.warn('GOOGLE_CHAT_WEBHOOK_URL not set — skipping Google Chat post.')
   }
+
+  await Promise.all(posts)
 }

--- a/meal-planner-task2/backend/src/jobs/cronLambda.ts
+++ b/meal-planner-task2/backend/src/jobs/cronLambda.ts
@@ -1,12 +1,20 @@
 import 'dotenv/config'
-import { QueryCommand, BatchGetCommand, BatchWriteCommand } from '@aws-sdk/lib-dynamodb'
+import { QueryCommand, BatchGetCommand, BatchWriteCommand, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import {
   getTomorrowString,
   isWeekend,
 } from '../utils/dateHelpers.js'
 import { writeAuditLog } from '../services/auditService.js'
-import type { UserItem, MealRecordItem } from '../types/index.js'
+import type { UserItem, MealRecordItem, MealScheduleItem } from '../types/index.js'
+
+const DEFAULT_SCHEDULE = {
+  lunchEnabled:          true,
+  snacksEnabled:         true,
+  iftarEnabled:          false,
+  eventDinnerEnabled:    false,
+  optionalDinnerEnabled: false,
+}
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
@@ -41,7 +49,22 @@ async function createRecords(): Promise<void> {
     return
   }
 
-  // Get all active users via GSI (replaces ACTIVE_USERS sentinel)
+  // 1. Fetch schedule for tomorrow (fall back to defaults if none published)
+  const scheduleResult = await dynamo.send(new GetCommand({
+    TableName: TABLES.MAIN,
+    Key: { PK: 'SCHEDULE', SK: date },
+  }))
+  const schedule = (scheduleResult.Item as MealScheduleItem | undefined) ?? DEFAULT_SCHEDULE
+
+  const defaults = {
+    lunch:          schedule.lunchEnabled          ? true : null,
+    snacks:         schedule.snacksEnabled         ? true : null,
+    iftar:          schedule.iftarEnabled          ? true : null,
+    eventDinner:    schedule.eventDinnerEnabled    ? true : null,
+    optionalDinner: schedule.optionalDinnerEnabled ? true : null,
+  }
+
+  // 2. Get all active users
   const gsiResult = await dynamo.send(new QueryCommand({
     TableName:                 TABLES.MAIN,
     IndexName:                 'status-email-index',
@@ -56,38 +79,96 @@ async function createRecords(): Promise<void> {
   }
 
   const discordIds = activeUsers.map(u => u.discordId)
-  console.log(`Creating records for ${discordIds.length} users on ${date}`)
+  console.log(`Processing ${discordIds.length} users for ${date}`)
 
-  // BatchWrite in chunks of 25 (DynamoDB limit)
-  const now = new Date().toISOString()
-  const chunks = chunkArray(discordIds, 25)
-
-  for (const chunk of chunks) {
-    await dynamo.send(new BatchWriteCommand({
+  // 3. BatchGet existing records to avoid overwriting confirmed choices
+  const existingRecords: MealRecordItem[] = []
+  for (const chunk of chunkArray(discordIds, 100)) {
+    const batchResult = await dynamo.send(new BatchGetCommand({
       RequestItems: {
-        [TABLES.MAIN]: chunk.map(discordId => ({
-          PutRequest: {
-            Item: {
-              PK:             `USER#${discordId}`,
-              SK:             `RECORD#${date}`,
-              discordId,
-              date,
-              lunch:          null,
-              snacks:         null,
-              iftar:          null,
-              eventDinner:    null,
-              optionalDinner: null,
-              workFromHome:   false,
-              createdAt:      now,
-              updatedAt:      now,
-            } satisfies Omit<MealRecordItem, 'teamId' | 'teamName'>,
-          },
-        })),
+        [TABLES.MAIN]: {
+          Keys: chunk.map(id => ({ PK: `USER#${id}`, SK: `RECORD#${date}` })),
+        },
       },
     }))
+    existingRecords.push(...((batchResult.Responses?.[TABLES.MAIN] ?? []) as MealRecordItem[]))
   }
 
-  console.log(`Done. ${discordIds.length} records created for ${date}.`)
+  const existingByUser = new Map(existingRecords.map(r => [r.discordId, r]))
+  const userMap        = new Map(activeUsers.map(u => [u.discordId, u]))
+
+  const noRecord  = discordIds.filter(id => !existingByUser.has(id))
+  const hasRecord = discordIds.filter(id =>  existingByUser.has(id))
+
+  const now = new Date().toISOString()
+
+  // 4. Create new records for users who have none
+  if (noRecord.length) {
+    for (const chunk of chunkArray(noRecord, 25)) {
+      await dynamo.send(new BatchWriteCommand({
+        RequestItems: {
+          [TABLES.MAIN]: chunk.map(discordId => {
+            const user = userMap.get(discordId)
+            return {
+              PutRequest: {
+                Item: {
+                  PK:             `USER#${discordId}`,
+                  SK:             `RECORD#${date}`,
+                  discordId,
+                  date,
+                  ...defaults,
+                  workFromHome:   false,
+                  teamId:         user?.teamId,
+                  teamName:       user?.teamName,
+                  createdAt:      now,
+                  updatedAt:      now,
+                } satisfies MealRecordItem,
+              },
+            }
+          }),
+        },
+      }))
+    }
+    console.log(`Created ${noRecord.length} new records.`)
+  }
+
+  // 5. For existing records, fill only null meal fields with schedule defaults
+  let filledCount = 0
+  for (const discordId of hasRecord) {
+    const record  = existingByUser.get(discordId)!
+    const updates: string[] = []
+    const values: Record<string, unknown> = { ':now': now }
+
+    const mealFields = [
+      { field: 'lunch',          key: ':lunch',   val: defaults.lunch },
+      { field: 'snacks',         key: ':snacks',  val: defaults.snacks },
+      { field: 'iftar',          key: ':iftar',   val: defaults.iftar },
+      { field: 'eventDinner',    key: ':ed',      val: defaults.eventDinner },
+      { field: 'optionalDinner', key: ':od',      val: defaults.optionalDinner },
+    ] as const
+
+    for (const { field, key, val } of mealFields) {
+      if (record[field] === null && val !== null) {
+        updates.push(`${field} = ${key}`)
+        values[key] = val
+      }
+    }
+
+    if (updates.length) {
+      await dynamo.send(new UpdateCommand({
+        TableName:                 TABLES.MAIN,
+        Key:                       { PK: `USER#${discordId}`, SK: `RECORD#${date}` },
+        UpdateExpression:          `SET ${updates.join(', ')}, updatedAt = :now`,
+        ExpressionAttributeValues: values,
+      }))
+      filledCount++
+    }
+  }
+
+  if (filledCount) console.log(`Filled null fields in ${filledCount} existing records.`)
+
+  const total = noRecord.length + filledCount
+  console.log(`Done. ${total} records written for ${date}.`)
 
   await writeAuditLog({
     actorDiscordId: 'SYSTEM',
@@ -95,7 +176,7 @@ async function createRecords(): Promise<void> {
     action:         'CREATE',
     entityType:     'MEAL_RECORD',
     entityId:       date,
-    metadata:       { count: discordIds.length },
+    metadata:       { created: noRecord.length, filled: filledCount, date },
   })
 }
 

--- a/meal-planner-task2/backend/src/jobs/cronLambda.ts
+++ b/meal-planner-task2/backend/src/jobs/cronLambda.ts
@@ -5,10 +5,12 @@ import {
   getTodayString,
   getTomorrowString,
   isWeekend,
+  isDateInPeriod,
+  getCurrentMonthKey,
 } from '../utils/dateHelpers.js'
 import { writeAuditLog } from '../services/auditService.js'
 import { getHeadcount, formatHeadcountMessage } from '../services/headcountService.js'
-import type { UserItem, MealRecordItem, MealScheduleItem } from '../types/index.js'
+import type { UserItem, MealRecordItem, MealScheduleItem, WfhPeriodItem } from '../types/index.js'
 
 const DEFAULT_SCHEDULE = {
   lunchEnabled:          true,
@@ -99,6 +101,20 @@ async function createRecords(): Promise<void> {
   const existingByUser = new Map(existingRecords.map(r => [r.discordId, r]))
   const userMap        = new Map(activeUsers.map(u => [u.discordId, u]))
 
+  // Check if tomorrow falls within a company-wide WFH period
+  const wfhPeriodsResult = await dynamo.send(new QueryCommand({
+    TableName:                 TABLES.MAIN,
+    KeyConditionExpression:    'PK = :pk',
+    ExpressionAttributeValues: { ':pk': 'WFHPERIOD' },
+  }))
+  const wfhPeriods  = (wfhPeriodsResult.Items ?? []) as WfhPeriodItem[]
+  const isGlobalWFH = wfhPeriods.some(p => isDateInPeriod(date, p.dateFrom, p.dateTo))
+
+  if (isGlobalWFH) console.log(`Global WFH period active for ${date} — all meals disabled, WFH = true.`)
+
+  // Track users whose WFH goes false → true (need counter increment)
+  const wfhIncrementIds: string[] = []
+
   const noRecord  = discordIds.filter(id => !existingByUser.has(id))
   const hasRecord = discordIds.filter(id =>  existingByUser.has(id))
 
@@ -118,8 +134,12 @@ async function createRecords(): Promise<void> {
                   SK:             `RECORD#${date}`,
                   discordId,
                   date,
-                  ...defaults,
-                  workFromHome:   false,
+                  lunch:          isGlobalWFH ? false : defaults.lunch,
+                  snacks:         isGlobalWFH ? false : defaults.snacks,
+                  iftar:          isGlobalWFH ? false : defaults.iftar,
+                  eventDinner:    isGlobalWFH ? false : defaults.eventDinner,
+                  optionalDinner: isGlobalWFH ? false : defaults.optionalDinner,
+                  workFromHome:   isGlobalWFH ? true  : false,
                   teamId:         user?.teamId,
                   teamName:       user?.teamName,
                   createdAt:      now,
@@ -132,42 +152,78 @@ async function createRecords(): Promise<void> {
       }))
     }
     console.log(`Created ${noRecord.length} new records.`)
+    if (isGlobalWFH) wfhIncrementIds.push(...noRecord)
   }
 
-  // 5. For existing records, fill only null meal fields with schedule defaults
+  // 5. For existing records:
+  //    - Global WFH day: override all meals → false, workFromHome → true
+  //    - Normal day: fill only null meal fields with schedule defaults
   let filledCount = 0
   for (const discordId of hasRecord) {
-    const record  = existingByUser.get(discordId)!
-    const updates: string[] = []
-    const values: Record<string, unknown> = { ':now': now }
+    const record = existingByUser.get(discordId)!
 
-    const mealFields = [
-      { field: 'lunch',          key: ':lunch',   val: defaults.lunch },
-      { field: 'snacks',         key: ':snacks',  val: defaults.snacks },
-      { field: 'iftar',          key: ':iftar',   val: defaults.iftar },
-      { field: 'eventDinner',    key: ':ed',      val: defaults.eventDinner },
-      { field: 'optionalDinner', key: ':od',      val: defaults.optionalDinner },
-    ] as const
-
-    for (const { field, key, val } of mealFields) {
-      if (record[field] === null && val !== null) {
-        updates.push(`${field} = ${key}`)
-        values[key] = val
-      }
-    }
-
-    if (updates.length) {
+    if (isGlobalWFH) {
       await dynamo.send(new UpdateCommand({
         TableName:                 TABLES.MAIN,
         Key:                       { PK: `USER#${discordId}`, SK: `RECORD#${date}` },
-        UpdateExpression:          `SET ${updates.join(', ')}, updatedAt = :now`,
-        ExpressionAttributeValues: values,
+        UpdateExpression:          'SET lunch = :f, snacks = :f, iftar = :f, eventDinner = :f, optionalDinner = :f, workFromHome = :t, updatedAt = :now',
+        ExpressionAttributeValues: { ':f': false, ':t': true, ':now': now },
       }))
+      if (!record.workFromHome) wfhIncrementIds.push(discordId)
       filledCount++
+    } else {
+      const updates: string[] = []
+      const values: Record<string, unknown> = { ':now': now }
+
+      const mealFields = [
+        { field: 'lunch',          key: ':lunch',   val: defaults.lunch },
+        { field: 'snacks',         key: ':snacks',  val: defaults.snacks },
+        { field: 'iftar',          key: ':iftar',   val: defaults.iftar },
+        { field: 'eventDinner',    key: ':ed',      val: defaults.eventDinner },
+        { field: 'optionalDinner', key: ':od',      val: defaults.optionalDinner },
+      ] as const
+
+      for (const { field, key, val } of mealFields) {
+        if (record[field] === null && val !== null) {
+          updates.push(`${field} = ${key}`)
+          values[key] = val
+        }
+      }
+
+      if (updates.length) {
+        await dynamo.send(new UpdateCommand({
+          TableName:                 TABLES.MAIN,
+          Key:                       { PK: `USER#${discordId}`, SK: `RECORD#${date}` },
+          UpdateExpression:          `SET ${updates.join(', ')}, updatedAt = :now`,
+          ExpressionAttributeValues: values,
+        }))
+        filledCount++
+      }
     }
   }
 
-  if (filledCount) console.log(`Filled null fields in ${filledCount} existing records.`)
+  if (isGlobalWFH && filledCount) console.log(`Overrode ${filledCount} existing records for global WFH day.`)
+  else if (filledCount)           console.log(`Filled null fields in ${filledCount} existing records.`)
+
+  // 6. Increment WFH counter for users transitioning false → true
+  if (wfhIncrementIds.length) {
+    const currentMonthKey = getCurrentMonthKey()
+    for (const discordId of wfhIncrementIds) {
+      const user = userMap.get(discordId)!
+      const isNewMonth = user.wfhMonth !== currentMonthKey
+      await dynamo.send(new UpdateCommand({
+        TableName:                 TABLES.MAIN,
+        Key:                       { PK: `USER#${discordId}`, SK: 'PROFILE' },
+        UpdateExpression:          'SET wfhCount = :count, wfhMonth = :month, updatedAt = :now',
+        ExpressionAttributeValues: {
+          ':count': isNewMonth ? 1 : user.wfhCount + 1,
+          ':month': currentMonthKey,
+          ':now':   now,
+        },
+      }))
+    }
+    console.log(`Incremented WFH counter for ${wfhIncrementIds.length} users.`)
+  }
 
   const total = noRecord.length + filledCount
   console.log(`Done. ${total} records written for ${date}.`)

--- a/meal-planner-task2/backend/src/services/adminService.ts
+++ b/meal-planner-task2/backend/src/services/adminService.ts
@@ -123,10 +123,18 @@ export async function getAllMealSchedules(): Promise<MealScheduleItem[]> {
 }
 
 export async function deleteMealSchedule(date: string): Promise<void> {
-  await dynamo.send(new DeleteCommand({
-    TableName: TABLES.MAIN,
-    Key: { PK: 'SCHEDULE', SK: date },
-  }))
+  try {
+    await dynamo.send(new DeleteCommand({
+      TableName:           TABLES.MAIN,
+      Key:                 { PK: 'SCHEDULE', SK: date },
+      ConditionExpression: 'attribute_exists(PK)',
+    }))
+  } catch (err: any) {
+    if (err.name === 'ConditionalCheckFailedException') {
+      throw new Error(`No schedule found for ${date}`)
+    }
+    throw err
+  }
 }
 
 export async function deleteMealScheduleWithAudit(

--- a/meal-planner-task2/backend/src/services/headcountService.ts
+++ b/meal-planner-task2/backend/src/services/headcountService.ts
@@ -100,3 +100,42 @@ export async function getHeadcount(date: string): Promise<HeadcountData> {
     occasionName:  schedule?.occasionName ?? null,
   }
 }
+
+/**
+ * Formats a HeadcountData object into a Discord-compatible message string.
+ * Shared by the /headcount command and the SEND_REPORT cron.
+ */
+export function formatHeadcountMessage(data: HeadcountData): string | null {
+  if (data.overallTotal === 0) return null
+
+  const occasionLine = data.occasionName ? ` — *${data.occasionName}*` : ''
+  const { mealTotals: m, workLocationSplit: w } = data
+
+  const mealLine = [
+    m.lunch          > 0 && `🍱 Lunch: **${m.lunch}**`,
+    m.snacks         > 0 && `🍪 Snacks: **${m.snacks}**`,
+    m.iftar          > 0 && `🌙 Iftar: **${m.iftar}**`,
+    m.eventDinner    > 0 && `🍽️ Event Dinner: **${m.eventDinner}**`,
+    m.optionalDinner > 0 && `🥘 Optional Dinner: **${m.optionalDinner}**`,
+  ].filter(Boolean).join('  ') || 'No meals opted in.'
+
+  const teamLines = data.teamBreakdown.map(t => {
+    const meals = [
+      t.lunch          > 0 && `L:${t.lunch}`,
+      t.snacks         > 0 && `S:${t.snacks}`,
+      t.iftar          > 0 && `I:${t.iftar}`,
+      t.eventDinner    > 0 && `ED:${t.eventDinner}`,
+      t.optionalDinner > 0 && `OD:${t.optionalDinner}`,
+    ].filter(Boolean).join(' ') || 'none'
+    return `  **${t.teamName}** (${t.totalMembers}) — ${meals}`
+  })
+
+  return [
+    `📊 **Headcount — ${data.date}**${occasionLine}`,
+    ``,
+    `🏢 Office: **${w.office}**  🏠 WFH: **${w.wfh}**  👥 Total: **${data.overallTotal}**`,
+    ``,
+    mealLine,
+    teamLines.length > 0 ? `\n**By team:**\n${teamLines.join('\n')}` : '',
+  ].filter(s => s !== '').join('\n')
+}


### PR DESCRIPTION
- Closes #39 

## What does this PR do?

Adds automated cron jobs for nightly record creation and morning headcount reporting, with Google Chat webhook support, 3-state meal token parsing for Google Chat, and global WFH period enforcement.

## Type of Change

- [x] New feature

## What was changed

**`cronLambda.ts`** — EventBridge-dispatched handler with two job types:

- `CREATE_RECORDS`: fetches all active users, BatchGets existing records for tomorrow, BatchWrites new records using schedule defaults (enabled meals → `true`, disabled → `null`), and fills only `null` fields on existing records via UpdateCommand so confirmed choices are never overwritten. On a global WFH day all meal fields are forced to `false` and `workFromHome` to `true` for every active user, and the monthly WFH counter is incremented for each user transitioning from `false → true`.
- `SEND_REPORT`: delegates to `getHeadcount(today)` + `formatHeadcountMessage` (shared with `/headcount` command) and posts the result to both webhooks.

**`headcountService.ts`** — `formatHeadcountMessage` extracted as a shared formatter used by both the `/headcount` command handler and the `SEND_REPORT` cron job.

**`postWebhook`** — posts to `DISCORD_WEBHOOK_URL` and `GOOGLE_CHAT_WEBHOOK_URL` in parallel via `Promise.all`. Discord receives `{ content }`, Google Chat receives `{ text }`.

**`_mealChoiceHelpers.ts` / `_proxyHelpers.ts`** — added `parseToken` helper giving Google Chat meal commands 3-state field input: `token` → `true`, `-token` → `false`, absent → `undefined` (carry-forward). Applies to all 6 fields: `lunch`, `snacks`, `iftar`, `eventdinner`, `optionaldinner`, `wfh`. Brings Google Chat to parity with Discord's native 3-state boolean option behaviour.

## Changelog

Feature: Nightly cron auto-creates tomorrow's meal records for all active users at 9 PM BST
Feature: Morning cron posts daily headcount report to Discord and Google Chat channels at 9 AM BST
Feature: Google Chat meal commands now support explicit opt-out syntax (`-lunch`, `-wfh`, etc.)
Feature: Company-wide WFH periods are enforced by the cron — all meals disabled, WFH counter incremented


## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2


## How to Test

Affected workflows:
- Nightly record pre-creation for all active users
- Morning headcount report delivery to channels
- Employee meal commands in Google Chat (create, update, proxy)

Specific checks:
- Trigger `CREATE_RECORDS` on a normal weekday — confirm records created with schedule defaults, existing confirmed choices untouched
- Trigger `CREATE_RECORDS` on a day covered by a WFH period — confirm all meals `false`, `workFromHome` `true`, `wfhCount` incremented
- Trigger `SEND_REPORT` — confirm message appears in both Discord and Google Chat with correct meal totals and team breakdown
- Run `/create-meal` and `/update-meal` in Google Chat using `-field` syntax — confirm explicit `false` is stored (not carry-forward)

