### PR TITLE
Implement containerized deployment in aws using makefile, replacing manual zip upload

### DIFF
--- a/meal-planner-task2/backend/.dockerignore
+++ b/meal-planner-task2/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+src/
+scripts/
+*.ts
+.env
+.env.*

--- a/meal-planner-task2/backend/Dockerfile
+++ b/meal-planner-task2/backend/Dockerfile
@@ -1,0 +1,3 @@
+FROM public.ecr.aws/lambda/nodejs:22
+COPY dist/ ${LAMBDA_TASK_ROOT}/
+# CMD is overridden per Lambda function at the AWS console/CLI level

--- a/meal-planner-task2/backend/Makefile
+++ b/meal-planner-task2/backend/Makefile
@@ -1,0 +1,35 @@
+ECR_REGISTRY = 211125488712.dkr.ecr.ap-southeast-1.amazonaws.com
+ECR_REPO     = trainee-rifat-mhpv2-backend
+IMAGE_URI    = $(ECR_REGISTRY)/$(ECR_REPO):latest
+MFA_ARN      = arn:aws:iam::211125488712:mfa/rifat-hp-craftsmen
+
+LAMBDA_DISCORD      = trainee-2026-rifat-discord-lambda-v2
+LAMBDA_GOOGLE       = trainee-2026-rifat-google-lambda-v2
+LAMBDA_CRON         = trainee-2026-rifat-cron-lambda-v2
+LAMBDA_DISCORD_AUTH = trainee-2026-rifat-discord-authorizer-v2
+LAMBDA_GOOGLE_AUTH  = trainee-2026-rifat-google-authorizer-v2
+
+.PHONY: build push deploy
+
+build:
+	npm run build
+	docker build --platform linux/amd64 --provenance=false -t $(ECR_REPO) .
+	docker tag $(ECR_REPO):latest $(IMAGE_URI)
+
+push:
+	@read -p "Enter MFA code: " code; \
+	creds=$$(aws sts get-session-token --serial-number $(MFA_ARN) --token-code $$code --query 'Credentials' --output json); \
+	AWS_ACCESS_KEY_ID=$$(echo $$creds | python -c "import sys,json; print(json.load(sys.stdin)['AccessKeyId'])") \
+	AWS_SECRET_ACCESS_KEY=$$(echo $$creds | python -c "import sys,json; print(json.load(sys.stdin)['SecretAccessKey'])") \
+	AWS_SESSION_TOKEN=$$(echo $$creds | python -c "import sys,json; print(json.load(sys.stdin)['SessionToken'])") \
+	sh -c ' \
+		aws ecr get-login-password --region ap-southeast-1 | docker login --username AWS --password-stdin $(ECR_REGISTRY) && \
+		docker push $(IMAGE_URI) && \
+		aws lambda update-function-code --function-name $(LAMBDA_DISCORD)      --image-uri $(IMAGE_URI) --region ap-southeast-1 && \
+		aws lambda update-function-code --function-name $(LAMBDA_GOOGLE)       --image-uri $(IMAGE_URI) --region ap-southeast-1 && \
+		aws lambda update-function-code --function-name $(LAMBDA_CRON)         --image-uri $(IMAGE_URI) --region ap-southeast-1 && \
+		aws lambda update-function-code --function-name $(LAMBDA_DISCORD_AUTH) --image-uri $(IMAGE_URI) --region ap-southeast-1 && \
+		aws lambda update-function-code --function-name $(LAMBDA_GOOGLE_AUTH)  --image-uri $(IMAGE_URI) --region ap-southeast-1 \
+	'
+
+deploy: build push


### PR DESCRIPTION
- Closes #61 

## What does this PR do?

Replaces the manual zip-upload deployment with a containerized approach. The backend is now packaged as a Docker image, pushed to ECR, and all Lambda functions are updated automatically via a Makefile — all in one `make deploy` command.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What was changed

Under the hood `make deploy` runs:

1. `npm run build` — bundles 5 Lambda handlers into `dist/` via esbuild
2. `docker build --platform linux/amd64 --provenance=false` — builds a single Docker image containing all 5 `dist/` files
3. `docker tag` — tags the local image with the ECR repository URI
4. `aws sts get-session-token` — prompts for MFA code and exchanges it for temporary AWS credentials (12hr session)
5. `aws ecr get-login-password | docker login` — authenticates Docker to ECR using the MFA session
6. `docker push` — uploads the image to ECR
7. `aws lambda update-function-code` — points each of the 5 Lambda functions to the new image

## Changelog

None: not user visible


## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**ECR Image**: https://ap-southeast-1.console.aws.amazon.com/ecr/repositories/private/211125488712/trainee-rifat-mhpv2-backend/_/details?region=ap-southeast-1
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2


## How to Test

1. Make any code change
2. Run `make deploy` and enter MFA code when prompted
3. Verify the image appears in ECR with the `latest` tag
4. Verify all 5 Lambda functions are updated with the new image URI



