### PR TITLE
End-to-end role-based testing across Discord and Google Chat to find bugs, inconsistencies, and unexpected command behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 gacp.sh
 exp/
 tech-docs/
+meal-planner-task1/terraform/

--- a/meal-planner-task2/backend/scripts/data/teams.yaml
+++ b/meal-planner-task2/backend/scripts/data/teams.yaml
@@ -7,7 +7,7 @@
 
 - teamId: team-beta
   name: Team Beta
-  leadId: "1467742734449377402"
+  leadId: "1071390812547580005"
 
 - teamId: team-gamma
   name: Team Gamma

--- a/meal-planner-task2/backend/scripts/data/users.yaml
+++ b/meal-planner-task2/backend/scripts/data/users.yaml
@@ -41,18 +41,18 @@
   status: ACTIVE
   teamId: team-alpha
 
-- discordId: "1071390812547580005"
-  name: Niloy Gabriel
-  email: niloy.gabriel@craftsmensoftware.com
+- discordId: "1467742734449377402"
+  name: Samin Yasar
+  email: samin.yasar@craftsmensoftware.com
   role: EMPLOYEE
   status: ACTIVE
   teamId: team-alpha
 
 # ── Team Beta ─────────────────────────────────────────────────────────────────
 
-- discordId: "1467742734449377402"
-  name: Samin Yasar
-  email: samin.yasar@craftsmensoftware.com
+- discordId: "1071390812547580005"
+  name: Niloy Gabriel
+  email: niloy.gabriel@craftsmensoftware.com
   role: LEAD
   status: ACTIVE
   teamId: team-beta

--- a/meal-planner-task2/backend/scripts/syncUsers.ts
+++ b/meal-planner-task2/backend/scripts/syncUsers.ts
@@ -48,6 +48,15 @@ async function syncUsers() {
   const now      = new Date().toISOString()
   const wfhMonth = getCurrentMonthKey()
 
+  // Build desired memberIds per team (ACTIVE users only) from yaml
+  const desiredMembers = new Map<string, Set<string>>()
+  for (const team of teams) desiredMembers.set(team.teamId, new Set())
+  for (const user of users) {
+    if (user.teamId && user.status === 'ACTIVE') {
+      desiredMembers.get(user.teamId)?.add(user.discordId)
+    }
+  }
+
   for (const user of users) {
     const teamName = user.teamId ? (teamMap.get(user.teamId) ?? undefined) : undefined
 
@@ -74,26 +83,27 @@ async function syncUsers() {
     }))
 
     console.log(`  ✓ ${user.discordId}  ${user.name.padEnd(20)} [${user.role}] [${user.status}]`)
+  }
 
-    // ── Sync team membership (discordId-based StringSet) ───────────────────
-    if (user.teamId) {
-      if (user.status === 'ACTIVE') {
-        await dynamo.send(new UpdateCommand({
-          TableName:                 TABLES.MAIN,
-          Key:                       { PK: 'TEAM', SK: user.teamId },
-          UpdateExpression:          'ADD memberIds :did',
-          ExpressionAttributeValues: { ':did': new Set([user.discordId]) },
-        }))
-      } else {
-        await dynamo.send(new UpdateCommand({
-          TableName:                 TABLES.MAIN,
-          Key:                       { PK: 'TEAM', SK: user.teamId },
-          UpdateExpression:          'DELETE memberIds :did',
-          ExpressionAttributeValues: { ':did': new Set([user.discordId]) },
-        }))
-      }
+  // ── Full-replace memberIds per team ────────────────────────────────────
+  // Overwrites the entire set so removed/deleted users don't linger.
+  console.log('\nSyncing team memberships...\n')
+  for (const [teamId, memberIds] of desiredMembers) {
+    if (memberIds.size > 0) {
+      await dynamo.send(new UpdateCommand({
+        TableName:                 TABLES.MAIN,
+        Key:                       { PK: 'TEAM', SK: teamId },
+        UpdateExpression:          'SET memberIds = :ids',
+        ExpressionAttributeValues: { ':ids': memberIds },
+      }))
+    } else {
+      await dynamo.send(new UpdateCommand({
+        TableName:                 TABLES.MAIN,
+        Key:                       { PK: 'TEAM', SK: teamId },
+        UpdateExpression:          'REMOVE memberIds',
+      }))
     }
-
+    console.log(`  ✓ ${teamId}  [${memberIds.size} active member(s)]`)
   }
 
   console.log('\nDone.\n')

--- a/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
+++ b/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
@@ -1,7 +1,7 @@
 import { GetCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import { AuthRequest, MealUpdateData, MealScheduleItem } from '../types/index.js'
-import { getTodayString, isWeekend, isDateInValidWindow } from '../utils/dateHelpers.js'
+import { getTodayString, isWeekend, isDateInValidWindow, MEAL_WINDOW_WEEKDAYS } from '../utils/dateHelpers.js'
 
 const DEFAULT_SCHEDULE = {
   lunchEnabled:          true,
@@ -76,6 +76,6 @@ export function validateMealDate(date: string): string | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date))  return 'Invalid date format. Use YYYY-MM-DD.'
   if (date <= getTodayString())             return "Cannot set meals for today or a past date. Today's record is locked."
   if (isWeekend(date))                     return 'Cannot set meals for weekends (Sat/Sun).'
-  if (!isDateInValidWindow(date))          return 'Date is outside the 7-weekday booking window.'
+  if (!isDateInValidWindow(date))          return `Date is outside the ${MEAL_WINDOW_WEEKDAYS}-weekday booking window.`
   return null
 }

--- a/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
+++ b/meal-planner-task2/backend/src/commands/_mealChoiceHelpers.ts
@@ -2,6 +2,7 @@ import { GetCommand } from '@aws-sdk/lib-dynamodb'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import { AuthRequest, MealUpdateData, MealScheduleItem } from '../types/index.js'
 import { getTodayString, isWeekend, isDateInValidWindow, MEAL_WINDOW_WEEKDAYS } from '../utils/dateHelpers.js'
+import { isDateInAnyWfhPeriod } from '../services/wfhService.js'
 
 const DEFAULT_SCHEDULE = {
   lunchEnabled:          true,
@@ -72,10 +73,11 @@ export async function parseMealOptions(req: AuthRequest): Promise<MealUpdateData
   }
 }
 
-export function validateMealDate(date: string): string | null {
+export async function validateMealDate(date: string): Promise<string | null> {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date))  return 'Invalid date format. Use YYYY-MM-DD.'
   if (date <= getTodayString())             return "Cannot set meals for today or a past date. Today's record is locked."
   if (isWeekend(date))                     return 'Cannot set meals for weekends (Sat/Sun).'
   if (!isDateInValidWindow(date))          return `Date is outside the ${MEAL_WINDOW_WEEKDAYS}-weekday booking window.`
+  if (await isDateInAnyWfhPeriod(date))    return 'Meal selection is disabled for this date (company-wide WFH period).'
   return null
 }

--- a/meal-planner-task2/backend/src/commands/bulkUpdate.ts
+++ b/meal-planner-task2/backend/src/commands/bulkUpdate.ts
@@ -75,6 +75,6 @@ export async function handleBulkUpdate(req: AuthRequest, res: Response): Promise
   const count = await applyBulkAction(memberIds, date, action as BulkAction, user.discordId)
 
   const label = ACTION_LABELS[action as BulkAction]
-  const msg   = `✅ **${label}** on **${date}**. (${count}/${memberIds.length} records updated)`
+  const msg   = `✔ **${label}** on **${date}**. (${count}/${memberIds.length} records updated)`
   res.json(isGoogle ? { text: msg } : { type: 4, data: { content: msg, flags: 64 } })
 }

--- a/meal-planner-task2/backend/src/commands/createEmployeeMeal.ts
+++ b/meal-planner-task2/backend/src/commands/createEmployeeMeal.ts
@@ -38,7 +38,7 @@ export async function handleCreateEmployeeMeal(req: AuthRequest, res: Response):
   }
 
   const data = await parseProxyMealOptions(req)
-  const err  = validateMealDate(data.date)
+  const err  = await validateMealDate(data.date)
   if (err) {
     res.json(isGoogle ? { text: err } : { type: 4, data: { content: err, flags: 64 } })
     return

--- a/meal-planner-task2/backend/src/commands/createMeal.ts
+++ b/meal-planner-task2/backend/src/commands/createMeal.ts
@@ -6,7 +6,7 @@ import { parseMealOptions, validateMealDate } from './_mealChoiceHelpers.js'
 export async function handleCreateMeal(req: AuthRequest, res: Response): Promise<void> {
   const data = await parseMealOptions(req)
 
-  const err = validateMealDate(data.date)
+  const err = await validateMealDate(data.date)
   if (err) {
     res.json({ type: 4, data: { content: err, flags: 64 } })
     return

--- a/meal-planner-task2/backend/src/commands/deleteSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/deleteSchedule.ts
@@ -17,6 +17,10 @@ export async function handleDeleteSchedule(req: AuthRequest, res: Response): Pro
     return
   }
 
-  await deleteMealScheduleWithAudit(date, req.user!.discordId)
-  res.json({ type: 4, data: { content: `Schedule for **${date}** deleted.`, flags: 64 } })
+  try {
+    await deleteMealScheduleWithAudit(date, req.user!.discordId)
+    res.json({ type: 4, data: { content: `Schedule for **${date}** deleted.`, flags: 64 } })
+  } catch (err: any) {
+    res.json({ type: 4, data: { content: err.message ?? 'Failed to delete schedule.', flags: 64 } })
+  }
 }

--- a/meal-planner-task2/backend/src/commands/employeeSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/employeeSchedule.ts
@@ -21,16 +21,20 @@ function formatDay(day: ScheduleDay): string {
   const label    = `${weekday}, ${dayMonth}`
   const prefix   = day.isToday ? '**Today** ' : ''
 
+  const isGlobalWFH   = !!day.globalWFH
+  const isPersonalWFH = !!day.record?.workFromHome
+
   const mealCols = MEALS.map((m, i) => {
     const enabled = day.schedule?.[m.key] as boolean | undefined
-    if (!enabled) return '➖'
+    if (!enabled || isGlobalWFH) return '➖'          // meal not offered
+    if (isPersonalWFH) return `${m.label} ❌`         // available but skipped (WFH)
     const chosen = day.record?.[MEAL_RECORD_KEYS[i]]
     if (chosen === true)  return `${m.label} ✅`
     if (chosen === false) return `${m.label} ❌`
     return `${m.label} ◽`
   }).join('  ')
 
-  const wfh = (day.record?.workFromHome || day.globalWFH) ? '  🏠' : ''
+  const wfh = (isGlobalWFH || isPersonalWFH) ? '  🏠' : ''
   return `${prefix}${label} =>  ${mealCols}${wfh}`
 }
 

--- a/meal-planner-task2/backend/src/commands/employeeSchedule.ts
+++ b/meal-planner-task2/backend/src/commands/employeeSchedule.ts
@@ -15,21 +15,23 @@ const MEALS: Array<{ key: keyof MealScheduleItem; label: string }> = [
 const MEAL_RECORD_KEYS = ['lunch', 'snacks', 'iftar', 'eventDinner', 'optionalDinner'] as const
 
 function formatDay(day: ScheduleDay): string {
-  const date   = new Date(day.date + 'T00:00:00Z')
-  const label  = date.toLocaleDateString('en-GB', { weekday: 'short', day: '2-digit', month: 'short', timeZone: 'UTC' })
-  const prefix = day.isToday ? '**Today** ' : ''
+  const date     = new Date(day.date + 'T00:00:00Z')
+  const weekday  = date.toLocaleDateString('en-GB', { weekday: 'short', timeZone: 'UTC' })
+  const dayMonth = date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', timeZone: 'UTC' })
+  const label    = `${weekday}, ${dayMonth}`
+  const prefix   = day.isToday ? '**Today** ' : ''
 
   const mealCols = MEALS.map((m, i) => {
     const enabled = day.schedule?.[m.key] as boolean | undefined
     if (!enabled) return '➖'
     const chosen = day.record?.[MEAL_RECORD_KEYS[i]]
-    if (chosen === true)  return `${m.label}:✅`
-    if (chosen === false) return `${m.label}:❌`
-    return `${m.label}:⬜`
+    if (chosen === true)  return `${m.label} ✅`
+    if (chosen === false) return `${m.label} ❌`
+    return `${m.label} ◽`
   }).join('  ')
 
   const wfh = (day.record?.workFromHome || day.globalWFH) ? '  🏠' : ''
-  return `${prefix}${label}  ${mealCols}${wfh}`
+  return `${prefix}${label} =>  ${mealCols}${wfh}`
 }
 
 export async function handleEmployeeSchedule(req: AuthRequest, res: Response): Promise<void> {
@@ -86,7 +88,7 @@ export async function handleEmployeeSchedule(req: AuthRequest, res: Response): P
   const days = await getMySchedule(targetId)
 
   const lines  = days.map(formatDay)
-  const legend = '*✅ opted in  ❌ opted out  ⬜ not set  ➖ not offered  🏠 WFH*'
+  const legend = '*✅ opted in   ❌ opted out   ◽ not set   ➖ not offered   🏠 WFH*'
 
   res.json({
     type: 4,

--- a/meal-planner-task2/backend/src/commands/listSchedules.ts
+++ b/meal-planner-task2/backend/src/commands/listSchedules.ts
@@ -3,6 +3,11 @@ import { AuthRequest } from '../types/index.js'
 import { getAllMealSchedules } from '../services/adminService.js'
 
 export async function handleListSchedules(_req: AuthRequest, res: Response): Promise<void> {
+  if (_req.user!.role !== 'ADMIN') {
+    res.json({ type: 4, data: { content: 'Only admins can view meal schedules.', flags: 64 } })
+    return
+  }
+
   const schedules = await getAllMealSchedules()
 
   if (schedules.length === 0) {

--- a/meal-planner-task2/backend/src/commands/mySchedule.ts
+++ b/meal-planner-task2/backend/src/commands/mySchedule.ts
@@ -21,16 +21,20 @@ function formatDay(day: ScheduleDay): string {
   const label   = `${weekday}, ${dayMonth}`
   const prefix  = day.isToday ? '**Today** ' : ''
 
+  const isGlobalWFH   = !!day.globalWFH
+  const isPersonalWFH = !!day.record?.workFromHome
+
   const mealCols = MEALS.map((m, i) => {
     const enabled = day.schedule?.[m.key] as boolean | undefined
-    if (!enabled) return '➖'                        // meal not offered
-    const chosen = day.record?.[MEAL_RECORD_KEYS[i]] // true | false | null | undefined
+    if (!enabled || isGlobalWFH) return '➖'          // meal not offered
+    if (isPersonalWFH) return `${m.label} ❌`         // available but skipped (WFH)
+    const chosen = day.record?.[MEAL_RECORD_KEYS[i]]  // true | false | null | undefined
     if (chosen === true)  return `${m.label} ✅`
     if (chosen === false) return `${m.label} ❌`
-    return `${m.label} ◽`                            // not set yet
+    return `${m.label} ◽`                             // not set yet
   }).join('  ')
 
-  const wfh = (day.record?.workFromHome || day.globalWFH) ? '  🏠' : ''
+  const wfh = (isGlobalWFH || isPersonalWFH) ? '  🏠' : ''
   return `${prefix}${label} =>  ${mealCols}${wfh}`
 }
 

--- a/meal-planner-task2/backend/src/commands/mySchedule.ts
+++ b/meal-planner-task2/backend/src/commands/mySchedule.ts
@@ -15,33 +15,35 @@ const MEALS: Array<{ key: keyof MealScheduleItem; label: string }> = [
 const MEAL_RECORD_KEYS = ['lunch', 'snacks', 'iftar', 'eventDinner', 'optionalDinner'] as const
 
 function formatDay(day: ScheduleDay): string {
-  const date   = new Date(day.date + 'T00:00:00Z')
-  const label  = date.toLocaleDateString('en-GB', { weekday: 'short', day: '2-digit', month: 'short', timeZone: 'UTC' })
-  const prefix = day.isToday ? '**Today** ' : ''
+  const date    = new Date(day.date + 'T00:00:00Z')
+  const weekday = date.toLocaleDateString('en-GB', { weekday: 'short', timeZone: 'UTC' })
+  const dayMonth = date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', timeZone: 'UTC' })
+  const label   = `${weekday}, ${dayMonth}`
+  const prefix  = day.isToday ? '**Today** ' : ''
 
   const mealCols = MEALS.map((m, i) => {
     const enabled = day.schedule?.[m.key] as boolean | undefined
-    if (!enabled) return '➖'                       // meal not offered
+    if (!enabled) return '➖'                        // meal not offered
     const chosen = day.record?.[MEAL_RECORD_KEYS[i]] // true | false | null | undefined
-    if (chosen === true)  return `${m.label}:✅`
-    if (chosen === false) return `${m.label}:❌`
-    return `${m.label}:⬜`                             // not set yet
+    if (chosen === true)  return `${m.label} ✅`
+    if (chosen === false) return `${m.label} ❌`
+    return `${m.label} ◽`                            // not set yet
   }).join('  ')
 
   const wfh = (day.record?.workFromHome || day.globalWFH) ? '  🏠' : ''
-  return `${prefix}${label}  ${mealCols}${wfh}`
+  return `${prefix}${label} =>  ${mealCols}${wfh}`
 }
 
 export async function handleMySchedule(req: AuthRequest, res: Response): Promise<void> {
   const days = await getMySchedule(req.user!.discordId)
 
   const lines = days.map(formatDay)
-  const legend = '*✅ opted in  ❌ opted out  ⬜ not set  ➖ not offered  🏠 WFH*'
+  const legend = '*✅ opted in   ❌ opted out   ◽ not set   ➖ not offered   🏠 WFH*'
 
   res.json({
     type: 4,
     data: {
-      content: `📅 **Your Meal Schedule**\n\n${lines.join('\n')}\n\n${legend}`,
+      content: `**Meal Schedule**\n\n${lines.join('\n')}\n\n${legend}`,
       flags: 64,
     },
   })

--- a/meal-planner-task2/backend/src/commands/participation.ts
+++ b/meal-planner-task2/backend/src/commands/participation.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express'
 import { AuthRequest } from '../types/index.js'
 import { getParticipation } from '../services/participationService.js'
+import { isDateInAnyWfhPeriod } from '../services/wfhService.js'
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
@@ -27,7 +28,10 @@ export async function handleParticipation(req: AuthRequest, res: Response): Prom
   // LEAD is scoped to their own team; ADMIN sees all
   const teamId = role === 'LEAD' ? req.user!.teamId : undefined
 
-  const data = await getParticipation(date, teamId)
+  const [data, isGlobalWFH] = await Promise.all([
+    getParticipation(date, teamId),
+    isDateInAnyWfhPeriod(date),
+  ])
 
   if (data.employees.length === 0) {
     res.json({ type: 4, data: { content: `No participation data found for **${date}**.`, flags: 64 } })
@@ -37,17 +41,21 @@ export async function handleParticipation(req: AuthRequest, res: Response): Prom
   const scopeLabel = role === 'LEAD'
     ? ` — *${data.employees[0]?.teamName ?? 'your team'}*`
     : ''
-  const header     = `👥 **Participation — ${date}**${scopeLabel}\n`
+  const wfhBanner  = isGlobalWFH ? '  🏠 *Company-wide WFH*' : ''
+  const header     = `👥 **Participation — ${date}**${scopeLabel}${wfhBanner}\n`
 
   const lines = data.employees.map(e => {
-    const wfh  = e.workFromHome ? '🏠' : '🏛️'
-    const meals = [
-      e.meals.lunch          === true  ? 'L ✅'  : e.meals.lunch          === false ? 'L ❌'  : '',
-      e.meals.snacks         === true  ? 'S ✅'  : e.meals.snacks         === false ? 'S ❌'  : '',
-      e.meals.iftar          === true  ? 'I ✅'  : e.meals.iftar          === false ? 'I ❌'  : '',
-      e.meals.eventDinner    === true  ? 'ED ✅' : e.meals.eventDinner    === false ? 'ED ❌' : '',
-      e.meals.optionalDinner === true  ? 'OD ✅' : e.meals.optionalDinner === false ? 'OD ❌' : '',
-    ].filter(Boolean).join('  ') || '—'
+    const isWFH = isGlobalWFH || e.workFromHome
+    const wfh   = isWFH ? '🏠' : '🏛️'
+    const meals = isWFH
+      ? '➖'
+      : ([
+          e.meals.lunch          === true  ? 'L ✅'  : e.meals.lunch          === false ? 'L ❌'  : '',
+          e.meals.snacks         === true  ? 'S ✅'  : e.meals.snacks         === false ? 'S ❌'  : '',
+          e.meals.iftar          === true  ? 'I ✅'  : e.meals.iftar          === false ? 'I ❌'  : '',
+          e.meals.eventDinner    === true  ? 'ED ✅' : e.meals.eventDinner    === false ? 'ED ❌' : '',
+          e.meals.optionalDinner === true  ? 'OD ✅' : e.meals.optionalDinner === false ? 'OD ❌' : '',
+        ].filter(Boolean).join('  ') || '—')
 
     const team = role === 'ADMIN' && e.teamName ? ` *[${e.teamName}]*` : ''
     return `${wfh} **${e.name}**${team} — ${meals}  **WFH:** ${e.wfhCount}`

--- a/meal-planner-task2/backend/src/commands/participation.ts
+++ b/meal-planner-task2/backend/src/commands/participation.ts
@@ -34,7 +34,9 @@ export async function handleParticipation(req: AuthRequest, res: Response): Prom
     return
   }
 
-  const scopeLabel = role === 'LEAD' ? ' *(your team)*' : ''
+  const scopeLabel = role === 'LEAD'
+    ? ` — *${data.employees[0]?.teamName ?? 'your team'}*`
+    : ''
   const header     = `👥 **Participation — ${date}**${scopeLabel}\n`
 
   const lines = data.employees.map(e => {
@@ -47,8 +49,8 @@ export async function handleParticipation(req: AuthRequest, res: Response): Prom
       e.meals.optionalDinner === true  ? 'OD ✅' : e.meals.optionalDinner === false ? 'OD ❌' : '',
     ].filter(Boolean).join('  ') || '—'
 
-    const team = e.teamName ? ` *[${e.teamName}]*` : ''
-    return `${wfh} **${e.name}**${team} — ${meals}  WFH: ${e.wfhCount}`
+    const team = role === 'ADMIN' && e.teamName ? ` *[${e.teamName}]*` : ''
+    return `${wfh} **${e.name}**${team} — ${meals}  **WFH:** ${e.wfhCount}`
   })
 
   res.json({

--- a/meal-planner-task2/backend/src/commands/participation.ts
+++ b/meal-planner-task2/backend/src/commands/participation.ts
@@ -38,17 +38,17 @@ export async function handleParticipation(req: AuthRequest, res: Response): Prom
   const header     = `👥 **Participation — ${date}**${scopeLabel}\n`
 
   const lines = data.employees.map(e => {
-    const wfh  = e.workFromHome ? '🏠' : '🏢'
+    const wfh  = e.workFromHome ? '🏠' : '🏛️'
     const meals = [
-      e.meals.lunch          === true  ? 'L:✅' : e.meals.lunch          === false ? 'L:❌' : '',
-      e.meals.snacks         === true  ? 'S:✅' : e.meals.snacks         === false ? 'S:❌' : '',
-      e.meals.iftar          === true  ? 'I:✅' : e.meals.iftar          === false ? 'I:❌' : '',
-      e.meals.eventDinner    === true  ? 'ED:✅': e.meals.eventDinner    === false ? 'ED:❌': '',
-      e.meals.optionalDinner === true  ? 'OD:✅': e.meals.optionalDinner === false ? 'OD:❌': '',
+      e.meals.lunch          === true  ? 'L ✅'  : e.meals.lunch          === false ? 'L ❌'  : '',
+      e.meals.snacks         === true  ? 'S ✅'  : e.meals.snacks         === false ? 'S ❌'  : '',
+      e.meals.iftar          === true  ? 'I ✅'  : e.meals.iftar          === false ? 'I ❌'  : '',
+      e.meals.eventDinner    === true  ? 'ED ✅' : e.meals.eventDinner    === false ? 'ED ❌' : '',
+      e.meals.optionalDinner === true  ? 'OD ✅' : e.meals.optionalDinner === false ? 'OD ❌' : '',
     ].filter(Boolean).join('  ') || '—'
 
     const team = e.teamName ? ` *[${e.teamName}]*` : ''
-    return `${wfh} **${e.name}**${team} — ${meals}  WFH/mo: ${e.wfhCount}`
+    return `${wfh} **${e.name}**${team} — ${meals}  WFH: ${e.wfhCount}`
   })
 
   res.json({

--- a/meal-planner-task2/backend/src/commands/teamMembers.ts
+++ b/meal-planner-task2/backend/src/commands/teamMembers.ts
@@ -3,6 +3,8 @@ import { AuthRequest } from '../types/index.js'
 import { getTeamMembers, getAllActiveMembers } from '../services/teamService.js'
 import type { TeamMemberView } from '../services/teamService.js'
 
+const WFH_MONTHLY_LIMIT = 5
+
 export async function handleTeamMembers(req: AuthRequest, res: Response): Promise<void> {
   const user = req.user!
 
@@ -24,7 +26,8 @@ export async function handleTeamMembers(req: AuthRequest, res: Response): Promis
 
     const lines = members.map(m => {
       const status = m.status === 'ACTIVE' ? '🟢' : '🔴'
-      return `${status} **${m.name}** *[${m.teamName}]* — WFH this month: ${m.wfhCount}`
+      const wfhLabel = m.wfhCount > WFH_MONTHLY_LIMIT ? `${m.wfhCount} ⚠️` : `${m.wfhCount}`
+      return `${status} **${m.name}** *[${m.teamName}]* — WFH: ${wfhLabel}`
     })
 
     const content = `👥 **All Employees** *(${members.length} active) — ${month}*\n\n${lines.join('\n')}`
@@ -47,7 +50,8 @@ export async function handleTeamMembers(req: AuthRequest, res: Response): Promis
 
   const lines = members.map((m: TeamMemberView) => {
     const status = m.status === 'ACTIVE' ? '🟢' : '🔴'
-    return `${status} **${m.name}** — WFH this month: ${m.wfhCount}`
+    const wfhLabel = m.wfhCount > WFH_MONTHLY_LIMIT ? `${m.wfhCount} ⚠️` : `${m.wfhCount}`
+    return `${status} **${m.name}** — WFH: ${wfhLabel}`
   })
 
   const content = `👥 **${teamName}** *(${members.length} member${members.length === 1 ? '' : 's'}) — ${month}*\n\n${lines.join('\n')}`

--- a/meal-planner-task2/backend/src/commands/teamMembers.ts
+++ b/meal-planner-task2/backend/src/commands/teamMembers.ts
@@ -27,7 +27,7 @@ export async function handleTeamMembers(req: AuthRequest, res: Response): Promis
     const lines = members.map(m => {
       const status = m.status === 'ACTIVE' ? '🟢' : '🔴'
       const wfhLabel = m.wfhCount > WFH_MONTHLY_LIMIT ? `${m.wfhCount} ⚠️` : `${m.wfhCount}`
-      return `${status} **${m.name}** *[${m.teamName}]* — WFH: ${wfhLabel}`
+      return `${status} **${m.name}** *[${m.teamName}]* — **WFH:** ${wfhLabel}`
     })
 
     const content = `👥 **All Employees** *(${members.length} active) — ${month}*\n\n${lines.join('\n')}`
@@ -51,7 +51,7 @@ export async function handleTeamMembers(req: AuthRequest, res: Response): Promis
   const lines = members.map((m: TeamMemberView) => {
     const status = m.status === 'ACTIVE' ? '🟢' : '🔴'
     const wfhLabel = m.wfhCount > WFH_MONTHLY_LIMIT ? `${m.wfhCount} ⚠️` : `${m.wfhCount}`
-    return `${status} **${m.name}** — WFH: ${wfhLabel}`
+    return `${status} **${m.name}** — **WFH:** ${wfhLabel}`
   })
 
   const content = `👥 **${teamName}** *(${members.length} member${members.length === 1 ? '' : 's'}) — ${month}*\n\n${lines.join('\n')}`

--- a/meal-planner-task2/backend/src/commands/updateEmployeeMeal.ts
+++ b/meal-planner-task2/backend/src/commands/updateEmployeeMeal.ts
@@ -38,7 +38,7 @@ export async function handleUpdateEmployeeMeal(req: AuthRequest, res: Response):
   }
 
   const data = await parseProxyMealOptions(req)
-  const err  = validateMealDate(data.date)
+  const err  = await validateMealDate(data.date)
   if (err) {
     res.json(isGoogle ? { text: err } : { type: 4, data: { content: err, flags: 64 } })
     return

--- a/meal-planner-task2/backend/src/commands/updateMeal.ts
+++ b/meal-planner-task2/backend/src/commands/updateMeal.ts
@@ -6,7 +6,7 @@ import { parseMealOptions, validateMealDate } from './_mealChoiceHelpers.js'
 export async function handleUpdateMeal(req: AuthRequest, res: Response): Promise<void> {
   const data = await parseMealOptions(req)
 
-  const err = validateMealDate(data.date)
+  const err = await validateMealDate(data.date)
   if (err) {
     res.json({ type: 4, data: { content: err, flags: 64 } })
     return

--- a/meal-planner-task2/backend/src/jobs/cronLambda.ts
+++ b/meal-planner-task2/backend/src/jobs/cronLambda.ts
@@ -230,7 +230,7 @@ async function createRecords(): Promise<void> {
 
   await postWebhook(
     `🌙 **Nightly records created — ${date}**\n` +
-    `✅ New: **${noRecord.length}**  📝 Filled: **${filledCount}**  👥 Total active users: **${discordIds.length}**`
+    `✔ New: **${noRecord.length}**  📝 Filled: **${filledCount}**  👥 Total active users: **${discordIds.length}**`
   )
 
   await writeAuditLog({

--- a/meal-planner-task2/backend/src/jobs/cronLambda.ts
+++ b/meal-planner-task2/backend/src/jobs/cronLambda.ts
@@ -112,9 +112,6 @@ async function createRecords(): Promise<void> {
 
   if (isGlobalWFH) console.log(`Global WFH period active for ${date} — all meals disabled, WFH = true.`)
 
-  // Track users whose WFH goes false → true (need counter increment)
-  const wfhIncrementIds: string[] = []
-
   const noRecord  = discordIds.filter(id => !existingByUser.has(id))
   const hasRecord = discordIds.filter(id =>  existingByUser.has(id))
 
@@ -152,7 +149,6 @@ async function createRecords(): Promise<void> {
       }))
     }
     console.log(`Created ${noRecord.length} new records.`)
-    if (isGlobalWFH) wfhIncrementIds.push(...noRecord)
   }
 
   // 5. For existing records:
@@ -169,7 +165,6 @@ async function createRecords(): Promise<void> {
         UpdateExpression:          'SET lunch = :f, snacks = :f, iftar = :f, eventDinner = :f, optionalDinner = :f, workFromHome = :t, updatedAt = :now',
         ExpressionAttributeValues: { ':f': false, ':t': true, ':now': now },
       }))
-      if (!record.workFromHome) wfhIncrementIds.push(discordId)
       filledCount++
     } else {
       const updates: string[] = []
@@ -205,25 +200,6 @@ async function createRecords(): Promise<void> {
   if (isGlobalWFH && filledCount) console.log(`Overrode ${filledCount} existing records for global WFH day.`)
   else if (filledCount)           console.log(`Filled null fields in ${filledCount} existing records.`)
 
-  // 6. Increment WFH counter for users transitioning false → true
-  if (wfhIncrementIds.length) {
-    const currentMonthKey = getCurrentMonthKey()
-    for (const discordId of wfhIncrementIds) {
-      const user = userMap.get(discordId)!
-      const isNewMonth = user.wfhMonth !== currentMonthKey
-      await dynamo.send(new UpdateCommand({
-        TableName:                 TABLES.MAIN,
-        Key:                       { PK: `USER#${discordId}`, SK: 'PROFILE' },
-        UpdateExpression:          'SET wfhCount = :count, wfhMonth = :month, updatedAt = :now',
-        ExpressionAttributeValues: {
-          ':count': isNewMonth ? 1 : user.wfhCount + 1,
-          ':month': currentMonthKey,
-          ':now':   now,
-        },
-      }))
-    }
-    console.log(`Incremented WFH counter for ${wfhIncrementIds.length} users.`)
-  }
 
   const total = noRecord.length + filledCount
   console.log(`Done. ${total} records written for ${date}.`)

--- a/meal-planner-task2/backend/src/services/headcountService.ts
+++ b/meal-planner-task2/backend/src/services/headcountService.ts
@@ -133,7 +133,7 @@ export function formatHeadcountMessage(data: HeadcountData): string | null {
   return [
     `📊 **Headcount — ${data.date}**${occasionLine}`,
     ``,
-    `🏢 Office: **${w.office}**  🏠 WFH: **${w.wfh}**  👥 Total: **${data.overallTotal}**`,
+    `🏛️ Office: **${w.office}**  🏠 WFH: **${w.wfh}**  👥 Total: **${data.overallTotal}**`,
     ``,
     mealLine,
     teamLines.length > 0 ? `\n**By team:**\n${teamLines.join('\n')}` : '',

--- a/meal-planner-task2/backend/src/services/headcountService.ts
+++ b/meal-planner-task2/backend/src/services/headcountService.ts
@@ -111,12 +111,15 @@ export function formatHeadcountMessage(data: HeadcountData): string | null {
   const occasionLine = data.occasionName ? ` — *${data.occasionName}*` : ''
   const { mealTotals: m, workLocationSplit: w } = data
 
+  const totalMeals = m.lunch + m.snacks + m.iftar + m.eventDinner + m.optionalDinner
+
   const mealLine = [
     m.lunch          > 0 && `🍱 Lunch: **${m.lunch}**`,
     m.snacks         > 0 && `🍪 Snacks: **${m.snacks}**`,
     m.iftar          > 0 && `🌙 Iftar: **${m.iftar}**`,
     m.eventDinner    > 0 && `🍽️ Event Dinner: **${m.eventDinner}**`,
     m.optionalDinner > 0 && `🥘 Optional Dinner: **${m.optionalDinner}**`,
+    `🧾 Total: **${totalMeals}**`,
   ].filter(Boolean).join('  ') || 'No meals opted in.'
 
   const teamLines = data.teamBreakdown.map(t => {
@@ -133,7 +136,7 @@ export function formatHeadcountMessage(data: HeadcountData): string | null {
   return [
     `📊 **Headcount — ${data.date}**${occasionLine}`,
     ``,
-    `🏛️ Office: **${w.office}**  🏠 WFH: **${w.wfh}**  👥 Total: **${data.overallTotal}**`,
+    `🏛️ Office: **${w.office}**  🏠 WFH: **${w.wfh}**`,
     ``,
     mealLine,
     teamLines.length > 0 ? `\n**By team:**\n${teamLines.join('\n')}` : '',

--- a/meal-planner-task2/backend/src/services/mealService.ts
+++ b/meal-planner-task2/backend/src/services/mealService.ts
@@ -5,6 +5,7 @@ import {
   getNextNWeekdays,
   isDateInPeriod,
   getCurrentMonthKey,
+  MEAL_WINDOW_WEEKDAYS,
 } from '../utils/dateHelpers.js'
 import { writeAuditLog } from './auditService.js'
 import type { MealRecordItem, MealScheduleItem, WfhPeriodItem, ScheduleDay, MealUpdateData, UserItem } from '../types/index.js'
@@ -35,6 +36,12 @@ export async function createOrUpdateMealRecord(
   const prevWfh = existing?.workFromHome ?? false
   const newWfh  = data.workFromHome !== undefined ? data.workFromHome : prevWfh
 
+  // When WFH transitions (false→true or true→false), unspecified meals reset to null
+  // so stale selections don't silently persist across WFH state changes.
+  const wfhTransition = data.workFromHome !== undefined && data.workFromHome !== prevWfh
+  const carry = <T>(incoming: T | undefined, stored: T | null | undefined): T | null =>
+    incoming !== undefined ? incoming : (wfhTransition ? null : (stored ?? null))
+
   // 4. Upsert the meal record (carry forward existing meal fields for omitted options)
   await dynamo.send(new PutCommand({
     TableName: TABLES.MAIN,
@@ -43,11 +50,11 @@ export async function createOrUpdateMealRecord(
       SK:             `RECORD#${data.date}`,
       discordId,
       date:           data.date,
-      lunch:          data.lunch          !== undefined ? data.lunch          : (existing?.lunch          ?? null),
-      snacks:         data.snacks         !== undefined ? data.snacks         : (existing?.snacks         ?? null),
-      iftar:          data.iftar          !== undefined ? data.iftar          : (existing?.iftar          ?? null),
-      eventDinner:    data.eventDinner    !== undefined ? data.eventDinner    : (existing?.eventDinner    ?? null),
-      optionalDinner: data.optionalDinner !== undefined ? data.optionalDinner : (existing?.optionalDinner ?? null),
+      lunch:          carry(data.lunch,          existing?.lunch),
+      snacks:         carry(data.snacks,         existing?.snacks),
+      iftar:          carry(data.iftar,          existing?.iftar),
+      eventDinner:    carry(data.eventDinner,    existing?.eventDinner),
+      optionalDinner: carry(data.optionalDinner, existing?.optionalDinner),
       workFromHome:   newWfh,
       teamId:         user.teamId,
       teamName:       user.teamName,
@@ -119,7 +126,7 @@ const DEFAULT_SCHEDULE = {
  */
 export async function getMySchedule(discordId: string): Promise<ScheduleDay[]> {
   const today   = getTodayString()
-  const dates   = getNextNWeekdays(7)   // next 7 weekdays starting today
+  const dates   = getNextNWeekdays(MEAL_WINDOW_WEEKDAYS)
   const endDate = dates[dates.length - 1]
 
   // 1. Query user's meal records for the weekday range

--- a/meal-planner-task2/backend/src/services/wfhService.ts
+++ b/meal-planner-task2/backend/src/services/wfhService.ts
@@ -2,6 +2,7 @@ import { PutCommand, QueryCommand, UpdateCommand, DeleteCommand } from '@aws-sdk
 import { randomUUID } from 'node:crypto'
 import { dynamo, TABLES } from '../config/dynamoClient.js'
 import { writeAuditLog } from './auditService.js'
+import { isDateInPeriod } from '../utils/dateHelpers.js'
 import type { WfhPeriodItem, CreateWfhPeriodData, UpdateWfhPeriodData } from '../types/index.js'
 
 export async function createWfhPeriod(
@@ -47,6 +48,11 @@ export async function listWfhPeriods(): Promise<WfhPeriodItem[]> {
     ExpressionAttributeValues: { ':pk': 'WFHPERIOD' },
   }))
   return (result.Items ?? []) as WfhPeriodItem[]
+}
+
+export async function isDateInAnyWfhPeriod(date: string): Promise<boolean> {
+  const periods = await listWfhPeriods()
+  return periods.some(p => isDateInPeriod(date, p.dateFrom, p.dateTo))
 }
 
 async function findById(id: string): Promise<WfhPeriodItem | undefined> {

--- a/meal-planner-task2/backend/src/utils/dateHelpers.ts
+++ b/meal-planner-task2/backend/src/utils/dateHelpers.ts
@@ -1,5 +1,10 @@
 import { addDays, format } from 'date-fns'
 
+// ── Config ────────────────────────────────────────────────────────────────
+
+// Number of weekdays ahead users can set/view meals (change here to resize the window)
+export const MEAL_WINDOW_WEEKDAYS = 7
+
 // ── Core helpers ──────────────────────────────────────────────────────────
 
 // Returns today as a UTC Date at midnight
@@ -42,9 +47,9 @@ export const getNextNWeekdays = (n: number, from: Date = getUTCToday()): string[
   return weekdays
 }
 
-// 7-weekday window starting from today (Mon–Fri only)
+// Valid booking window starting from today (Mon–Fri only)
 export const getValidDateRange = (): { start: string; end: string } => {
-  const weekdays = getNextNWeekdays(7)
+  const weekdays = getNextNWeekdays(MEAL_WINDOW_WEEKDAYS)
   return { start: weekdays[0], end: weekdays[weekdays.length - 1] }
 }
 

--- a/meal-planner-task2/jenkins/docker-compose.yaml
+++ b/meal-planner-task2/jenkins/docker-compose.yaml
@@ -1,0 +1,14 @@
+services:
+  jenkins:
+    image: jenkins/jenkins:lts
+    container_name: jenkins
+    ports:
+      - "8080:8080"
+      - "50000:50000"
+    volumes:
+      - jenkins_home:/var/jenkins_home
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+volumes:
+  jenkins_home:


### PR DESCRIPTION
- Closes #63 


## What does this PR do?

A series of bug fixes and small improvements on top of the previous iteration — covering meal selection logic, WFH period enforcement, headcount accuracy, access control, and display formatting.

## Type of Change

- [x] Bug fix
- [x] Refactor

## What was changed

- **Global WFH enforcement on meal writes** — `validateMealDate` now blocks meal selection on dates covered by a WFH period. The cron `CREATE_RECORDS` also overrides existing records on global WFH days (sets all meals to `false`, `workFromHome` to `true`) instead of just filling nulls.
- **WFH counter exclusion for global WFH days** — `mealService` no longer increments/decrements `wfhCount` when the WFH transition is driven by a global WFH period, preventing inflated personal WFH counts.
- **Meal selection logic fix** — corrected carry-forward behaviour when WFH state transitions; stale meal selections now reset to `null` on WFH toggle instead of silently persisting.
- **Headcount total fix** — `formatHeadcountMessage` now correctly re-calculates total meals from aggregated counts rather than using a stale value.
- **`list-schedules` access control** — restricted to ADMIN only; also added a not-found error response in `delete-schedule`.
- **Configurable meal window** — `MEAL_WINDOW_WEEKDAYS` extracted as a named constant in `dateHelpers.ts` so the booking window size can be changed in one place.
- **Display formatting** — replaced heavy emoji with thinner alternatives and added consistent spacing across all command responses.
- **Seed data updates** — `users.yaml`, `teams.yaml`, and `syncUsers.ts` updated to reflect current team/user state.

## Changelog

- Bugfix: Meal selection is now blocked on company-wide WFH dates
- Bugfix: Personal WFH count no longer increments on global WFH days
- Bugfix: WFH toggle no longer silently carries forward stale meal selections
- Bugfix: `/headcount` total meal count is now accurate
- Bugfix: `/list-schedules` is now restricted to ADMIN only
- Meal window size refactor and formatting changes are not user-visible


## Test resources
**Invitation to Discord Server**: https://discord.gg/YUubbepy
**Google Chat Space URL**: https://chat.google.com/u/0/app/chat/AAQAMUCLkFk
**API Gateway Endpoint**:  https://5f1tgkgcr8.execute-api.ap-southeast-1.amazonaws.com/
**ECR Image**: https://ap-southeast-1.console.aws.amazon.com/ecr/repositories/private/211125488712/trainee-rifat-mhpv2-backend/_/details?region=ap-southeast-1
**DynamoDB Table**: https://ap-southeast-1.console.aws.amazon.com/dynamodbv2/home?region=ap-southeast-1#table?name=trainee-2026-rifat-mhp-v2


## How to Change Role

```
aws dynamodb update-item \
  --table-name <table-name> \
  --key '{"PK":{"S":"USER#<discord-id>"},"SK":{"S":"PROFILE"}}' \
  --update-expression "SET #role = :role" \
  --expression-attribute-names '{"#role":"role"}' \
  --expression-attribute-values '{":role":{"S":"<ROLE>"}}' \
  --region <aws-region>
```


## How to Test

1. Set a WFH period for tomorrow via `/set-wfh-period` and attempt `/my-meal` — should be blocked
2. Run the `CREATE_RECORDS` cron for a global WFH date and verify all records have `workFromHome: true` and all meals `false`
3. Toggle WFH on a meal record and verify stale meal fields reset to `null`
4. Run `/headcount` and verify the total count matches the sum of individual meal counts
5. Attempt `/list-schedules` as a non-ADMIN — should be rejected

