### PR TITLE
async communication and events using sns-sqs-eventbridge pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ meal-planner-task2/
 async-ui-react-query/
 .vercel/
 .env.local
+routing-and-security/
+form-validation/

--- a/aws-mfa-session.py
+++ b/aws-mfa-session.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+
+MFA_SERIAL_NUMBER = "arn:aws:iam::211125488712:mfa/rifat-hp-craftsmen"
+DURATION_SECONDS = 43200  # 12 hours
+
+def main():
+    # Prompt for MFA token (to stderr so it doesn't interfere with eval)
+    sys.stderr.write("Enter your MFA token: ")
+    sys.stderr.flush()
+    mfa_token = input().strip()
+
+    if not mfa_token:
+        print("Error: MFA token cannot be empty", file=sys.stderr)
+        sys.exit(1)
+
+    sys.stderr.write("Getting session token...\n")
+    sys.stderr.flush()
+
+    try:
+        # Call AWS STS to get session token
+        result = subprocess.run([
+            "aws", "sts", "get-session-token",
+            "--serial-number", MFA_SERIAL_NUMBER,
+            "--token-code", mfa_token,
+            "--duration-seconds", str(DURATION_SECONDS)
+        ], capture_output=True, text=True, check=True)
+
+        response = json.loads(result.stdout)
+
+        # Extract credentials
+        access_key_id = response["Credentials"]["AccessKeyId"]
+        secret_access_key = response["Credentials"]["SecretAccessKey"]
+        session_token = response["Credentials"]["SessionToken"]
+        expiration = response["Credentials"]["Expiration"]
+
+        # Output shell export commands to stdout (for eval)
+        print(f'export AWS_ACCESS_KEY_ID="{access_key_id}"')
+        print(f'export AWS_SECRET_ACCESS_KEY="{secret_access_key}"')
+        print(f'export AWS_SESSION_TOKEN="{session_token}"')
+
+        # Print success message to stderr
+        print(f"\n✓ AWS Session created successfully!", file=sys.stderr)
+        print(f"Session expires at: {expiration}", file=sys.stderr)
+
+    except subprocess.CalledProcessError as e:
+        print("Error: Failed to get session token", file=sys.stderr)
+        print(e.stderr, file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print("Error: Failed to parse AWS response", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/sns-sqs-eventbridge/.gitignore
+++ b/sns-sqs-eventbridge/.gitignore
@@ -1,0 +1,39 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files (they contain sensitive data)
+*.tfvars
+*.tfvars.json
+
+# Ignore override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore plan files
+*.tfplan
+
+# OS files
+.DS_Store
+*.swp
+*.swo
+*~
+
+# IDE
+.idea/
+.vscode/
+*.iml
+docs/

--- a/sns-sqs-eventbridge/README.md
+++ b/sns-sqs-eventbridge/README.md
@@ -1,0 +1,168 @@
+# SNS/SQS Message Processing System
+
+Serverless AWS infrastructure that receives JSON messages from SQS, routes them based on a message attribute, stores valid messages in DynamoDB, and emails admins about bad or failed messages.
+
+**Region:** Singapore (ap-southeast-1)  
+**Resource prefix:** `trainee-rifat-`
+
+---
+
+## Architecture
+
+```
+SQS Queue
+  └─ EventBridge Pipe (batch: 5, REQUEST_RESPONSE)
+       └─ Step Function (Express)
+            ├─ type="good"           → DynamoDB
+            ├─ type="bad"            → SNS → email
+            └─ missing/invalid type  → SNS → email
+
+Retry / failure path:
+  SQS retries failed message after 30s
+  After 2 failures → DLQ
+  DLQ → EventBridge Pipe (batch: 1) → SNS → email (message deleted from DLQ after send)
+```
+
+### AWS Resources
+
+| Resource | Name |
+|---|---|
+| SQS Queue | `trainee-rifat-message-processor-queue` |
+| SQS DLQ | `trainee-rifat-message-processor-dlq` |
+| EventBridge Pipe (main) | `trainee-rifat-message-processor-sqs-to-sf` |
+| EventBridge Pipe (DLQ) | `trainee-rifat-message-processor-dlq-to-sns` |
+| Step Function | `trainee-rifat-message-processor-processor` |
+| DynamoDB Table | `trainee-rifat-message-processor-messages` |
+| SNS (bad messages) | `trainee-rifat-message-processor-bad-message-notifications` |
+| SNS (DLQ alerts) | `trainee-rifat-message-processor-dlq-notifications` |
+
+---
+
+## Message Format
+
+**Body** (JSON string):
+```json
+{ "id": 1, "content": "your message" }
+```
+
+**Message attribute** `type` (String): `"good"` or `"bad"`
+
+> The `type` field is a **message attribute**, not part of the body.
+
+---
+
+## Deploy
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+# Set admin_email in terraform.tfvars
+
+terraform init
+terraform apply
+```
+
+After apply, check inbox and **confirm both SNS subscription emails** before testing — emails won't arrive until confirmed.
+
+---
+
+## Send Test Messages
+
+```bash
+QUEUE_URL=$(terraform output -raw sqs_main_queue_url)
+
+# Good message → stored in DynamoDB
+aws sqs send-message \
+  --queue-url $QUEUE_URL \
+  --message-body '{"id": 1, "content": "hello"}' \
+  --message-attributes '{"type": {"DataType": "String", "StringValue": "good"}}' \
+  --region ap-southeast-1
+
+# Bad message → email alert
+aws sqs send-message \
+  --queue-url $QUEUE_URL \
+  --message-body '{"id": 2, "content": "hello"}' \
+  --message-attributes '{"type": {"DataType": "String", "StringValue": "bad"}}' \
+  --region ap-southeast-1
+
+# Missing type attribute → email alert
+aws sqs send-message \
+  --queue-url $QUEUE_URL \
+  --message-body '{"id": 3, "content": "hello"}' \
+  --region ap-southeast-1
+
+# Invalid body (triggers retry → DLQ → email after ~60s)
+aws sqs send-message \
+  --queue-url $QUEUE_URL \
+  --message-body 'NOT JSON' \
+  --message-attributes '{"type": {"DataType": "String", "StringValue": "good"}}' \
+  --region ap-southeast-1
+```
+
+---
+
+## Verify Results
+
+```bash
+cd terraform
+
+# Check DynamoDB for stored good messages
+aws dynamodb scan \
+  --table-name $(terraform output -raw dynamodb_table_name) \
+  --region ap-southeast-1
+
+# Check DLQ message count
+aws sqs get-queue-attributes \
+  --queue-url $(terraform output -raw sqs_dlq_url) \
+  --attribute-names ApproximateNumberOfMessages \
+  --region ap-southeast-1
+```
+
+---
+
+## Logs
+
+| What | Where |
+|---|---|
+| Pipe (main) execution details | CloudWatch → `/aws/pipes/trainee-rifat-message-processor-sqs-to-sf` |
+| Pipe (DLQ) execution details | CloudWatch → `/aws/pipes/trainee-rifat-message-processor-dlq-to-sns` |
+| Step Function state transitions | CloudWatch → `/aws/states/trainee-rifat-message-processor-processor` |
+
+> Step Function executions are **not** visible in the SF console (Express workflow) — CloudWatch logs are the only view.
+
+---
+
+## Configuration
+
+Edit `terraform/terraform.tfvars`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `admin_email` | — | **Required.** Email for all SNS alerts |
+| `aws_region` | `ap-southeast-1` | AWS region |
+| `sqs_visibility_timeout` | `30` | Seconds before a failed message is retried |
+| `max_receive_count` | `2` | Failures before message moves to DLQ |
+| `eventbridge_batch_size` | `5` | Messages per SF invocation (max 10) |
+
+---
+
+## Cost Estimate
+
+All resources are pay-per-use. No idle cost.
+
+| Service | Pricing |
+|---|---|
+| SQS | $0.40 / million requests |
+| EventBridge Pipe | $0.35 / DPU-hour |
+| Step Functions (Express) | $1.00 / million executions + $0.00001 / state transition |
+| DynamoDB | $1.25 / million write units |
+| SNS | $0.50 / million notifications |
+
+---
+
+## Cleanup
+
+```bash
+cd terraform
+terraform destroy
+```

--- a/sns-sqs-eventbridge/terraform/.terraform.lock.hcl
+++ b/sns-sqs-eventbridge/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/sns-sqs-eventbridge/terraform/eventbridge.tf
+++ b/sns-sqs-eventbridge/terraform/eventbridge.tf
@@ -1,0 +1,174 @@
+resource "aws_iam_role" "eventbridge_pipe_role" {
+  name = "${var.project_name}-eventbridge-pipe-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "pipes.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Permission for EventBridge Pipe to read from SQS
+resource "aws_iam_role_policy" "eventbridge_pipe_sqs_source" {
+  name = "${var.project_name}-eventbridge-pipe-sqs-source"
+  role = aws_iam_role.eventbridge_pipe_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes"
+        ]
+        Resource = aws_sqs_queue.main.arn
+      }
+    ]
+  })
+}
+
+# Permission for EventBridge Pipe to invoke Step Function
+resource "aws_iam_role_policy" "eventbridge_pipe_stepfunctions_target" {
+  name = "${var.project_name}-eventbridge-pipe-stepfunctions-target"
+  role = aws_iam_role.eventbridge_pipe_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "states:StartSyncExecution"
+        ]
+        Resource = aws_sfn_state_machine.message_processor.arn
+      }
+    ]
+  })
+}
+
+# EventBridge Pipe: SQS -> Step Function (REQUEST_RESPONSE mode)
+resource "aws_pipes_pipe" "sqs_to_stepfunctions" {
+  name             = "${var.project_name}-sqs-to-sf"
+  description      = "EventBridge Pipe to route SQS messages to Step Function"
+  role_arn         = aws_iam_role.eventbridge_pipe_role.arn
+  source           = aws_sqs_queue.main.arn
+  target           = aws_sfn_state_machine.message_processor.arn
+  desired_state    = "RUNNING"
+
+  source_parameters {
+    sqs_queue_parameters {
+      batch_size                         = var.eventbridge_batch_size
+      maximum_batching_window_in_seconds = var.eventbridge_batching_window
+    }
+  }
+
+  target_parameters {
+    step_function_state_machine_parameters {
+      invocation_type = "REQUEST_RESPONSE"
+    }
+  }
+
+  log_configuration {
+    level                  = "TRACE"
+    include_execution_data = ["ALL"]
+    cloudwatch_logs_log_destination {
+      log_group_arn = aws_cloudwatch_log_group.pipe_logs.arn
+    }
+  }
+
+  depends_on = [aws_iam_role_policy.eventbridge_pipe_logs]
+}
+
+# ── DLQ → SNS Pipe ─────────────────────────────────────────────────────────────
+# CloudWatch alarm only fires on OK→ALARM transition, so it misses subsequent
+# DLQ messages if the alarm is already in ALARM state. This pipe fires for
+# every individual message that lands in the DLQ.
+
+resource "aws_iam_role" "dlq_pipe_role" {
+  name = "${var.project_name}-dlq-pipe-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "pipes.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "dlq_pipe_sqs" {
+  name = "${var.project_name}-dlq-pipe-sqs"
+  role = aws_iam_role.dlq_pipe_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
+      Resource = aws_sqs_queue.dlq.arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "dlq_pipe_sns" {
+  name = "${var.project_name}-dlq-pipe-sns"
+  role = aws_iam_role.dlq_pipe_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sns:Publish"]
+      Resource = aws_sns_topic.dlq_notifications.arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "dlq_pipe_logs" {
+  name = "${var.project_name}-dlq-pipe-logs"
+  role = aws_iam_role.dlq_pipe_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+      Resource = "${aws_cloudwatch_log_group.dlq_pipe_logs.arn}:*"
+    }]
+  })
+}
+
+resource "aws_pipes_pipe" "dlq_to_sns" {
+  name          = "${var.project_name}-dlq-to-sns"
+  description   = "Forward every DLQ message to SNS — fires per message unlike CW alarm"
+  role_arn      = aws_iam_role.dlq_pipe_role.arn
+  source        = aws_sqs_queue.dlq.arn
+  target        = aws_sns_topic.dlq_notifications.arn
+  desired_state = "RUNNING"
+
+  source_parameters {
+    sqs_queue_parameters {
+      batch_size = 1
+    }
+  }
+
+  log_configuration {
+    level                  = "TRACE"
+    include_execution_data = ["ALL"]
+    cloudwatch_logs_log_destination {
+      log_group_arn = aws_cloudwatch_log_group.dlq_pipe_logs.arn
+    }
+  }
+
+  depends_on = [aws_iam_role_policy.dlq_pipe_logs]
+}

--- a/sns-sqs-eventbridge/terraform/logs.tf
+++ b/sns-sqs-eventbridge/terraform/logs.tf
@@ -1,0 +1,70 @@
+# ── CloudWatch Log Groups ──────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "pipe_logs" {
+  name              = "/aws/pipes/${var.project_name}-sqs-to-sf"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "dlq_pipe_logs" {
+  name              = "/aws/pipes/${var.project_name}-dlq-to-sns"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "sf_logs" {
+  name              = "/aws/states/${var.project_name}-processor"
+  retention_in_days = 7
+}
+
+# ── IAM: Pipe role → CloudWatch Logs ──────────────────────────────────────────
+
+resource "aws_iam_role_policy" "eventbridge_pipe_logs" {
+  name = "${var.project_name}-eventbridge-pipe-logs"
+  role = aws_iam_role.eventbridge_pipe_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+      Resource = "${aws_cloudwatch_log_group.pipe_logs.arn}:*"
+    }]
+  })
+}
+
+# ── IAM: SF role → CloudWatch Logs ────────────────────────────────────────────
+# Express workflows write logs via a log delivery mechanism that requires
+# a broader set of logs:* actions on the role.
+
+resource "aws_iam_role_policy" "step_function_logs" {
+  name = "${var.project_name}-step-function-logs"
+  role = aws_iam_role.step_function_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogDelivery",
+          "logs:GetLogDelivery",
+          "logs:UpdateLogDelivery",
+          "logs:DeleteLogDelivery",
+          "logs:ListLogDeliveries",
+          "logs:PutResourcePolicy",
+          "logs:DescribeResourcePolicies",
+          "logs:DescribeLogGroups"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["logs:PutLogEvents"]
+        Resource = "${aws_cloudwatch_log_group.sf_logs.arn}:*"
+      }
+    ]
+  })
+}
+

--- a/sns-sqs-eventbridge/terraform/main.tf
+++ b/sns-sqs-eventbridge/terraform/main.tf
@@ -1,0 +1,102 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = var.project_name
+      ManagedBy   = "Terraform"
+    }
+  }
+}
+
+# SQS Dead Letter Queue
+resource "aws_sqs_queue" "dlq" {
+  name                      = "${var.project_name}-dlq"
+  message_retention_seconds = 1209600 # 14 days
+
+  tags = {
+    Name = "${var.project_name}-dlq"
+  }
+}
+
+# SQS Primary Queue with DLQ redrive policy
+resource "aws_sqs_queue" "main" {
+  name                       = "${var.project_name}-queue"
+  visibility_timeout_seconds = var.sqs_visibility_timeout
+  message_retention_seconds  = 1209600 # 14 days
+  receive_wait_time_seconds  = 20      # Long polling
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dlq.arn
+    maxReceiveCount     = var.max_receive_count
+  })
+
+  tags = {
+    Name = "${var.project_name}-main-queue"
+  }
+
+  depends_on = [aws_sqs_queue.dlq]
+}
+
+# DynamoDB table for good messages
+resource "aws_dynamodb_table" "messages" {
+  name           = "${var.project_name}-messages"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "N"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-messages-table"
+  }
+}
+
+# SNS Topic for DLQ notifications
+resource "aws_sns_topic" "dlq_notifications" {
+  name = "${var.project_name}-dlq-notifications"
+
+  tags = {
+    Name = "${var.project_name}-dlq-topic"
+  }
+}
+
+# SNS Topic for bad message notifications
+resource "aws_sns_topic" "bad_message_notifications" {
+  name = "${var.project_name}-bad-message-notifications"
+
+  tags = {
+    Name = "${var.project_name}-bad-message-topic"
+  }
+}
+
+# SNS Email subscription for DLQ (requires manual confirmation)
+resource "aws_sns_topic_subscription" "dlq_email" {
+  topic_arn = aws_sns_topic.dlq_notifications.arn
+  protocol  = "email"
+  endpoint  = var.admin_email
+}
+
+# SNS Email subscription for bad messages (requires manual confirmation)
+resource "aws_sns_topic_subscription" "bad_message_email" {
+  topic_arn = aws_sns_topic.bad_message_notifications.arn
+  protocol  = "email"
+  endpoint  = var.admin_email
+}

--- a/sns-sqs-eventbridge/terraform/outputs.tf
+++ b/sns-sqs-eventbridge/terraform/outputs.tf
@@ -1,0 +1,65 @@
+output "sqs_main_queue_url" {
+  description = "URL of the main SQS queue"
+  value       = aws_sqs_queue.main.url
+}
+
+output "sqs_main_queue_arn" {
+  description = "ARN of the main SQS queue"
+  value       = aws_sqs_queue.main.arn
+}
+
+output "sqs_dlq_url" {
+  description = "URL of the Dead Letter Queue"
+  value       = aws_sqs_queue.dlq.url
+}
+
+output "sqs_dlq_arn" {
+  description = "ARN of the Dead Letter Queue"
+  value       = aws_sqs_queue.dlq.arn
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table for messages"
+  value       = aws_dynamodb_table.messages.name
+}
+
+output "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = aws_dynamodb_table.messages.arn
+}
+
+output "sns_bad_message_topic_arn" {
+  description = "ARN of the SNS topic for bad message notifications"
+  value       = aws_sns_topic.bad_message_notifications.arn
+}
+
+output "sns_dlq_topic_arn" {
+  description = "ARN of the SNS topic for DLQ notifications"
+  value       = aws_sns_topic.dlq_notifications.arn
+}
+
+output "step_function_arn" {
+  description = "ARN of the Step Function state machine"
+  value       = aws_sfn_state_machine.message_processor.arn
+}
+
+output "eventbridge_pipe_name" {
+  description = "Name of the EventBridge Pipe"
+  value       = aws_pipes_pipe.sqs_to_stepfunctions.name
+}
+
+output "cost_estimation_note" {
+  description = "Cost estimation for deployed resources"
+  value = <<-EOT
+    Cost Estimation:
+    - SQS: $0.40 per million requests (pay-per-request)
+    - DynamoDB: On-demand billing (pay-per-request)
+    - Step Functions: $0.000025 per state transition (approximately)
+    - SNS: $0.50 per million notifications
+    - EventBridge Pipe: $0.35 per DPU-hour (default 1 DPU)
+
+    For 10 messages/batch processing:
+    Estimated monthly cost ~$5-15 (depending on volume and error rate)
+    See AWS Pricing pages for exact calculations based on your volume.
+  EOT
+}

--- a/sns-sqs-eventbridge/terraform/step_function.tf
+++ b/sns-sqs-eventbridge/terraform/step_function.tf
@@ -1,0 +1,189 @@
+resource "aws_iam_role" "step_function_role" {
+  name = "${var.project_name}-step-function-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "states.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "step_function_dynamodb" {
+  name = "${var.project_name}-step-function-dynamodb"
+  role = aws_iam_role.step_function_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["dynamodb:PutItem"]
+        Resource = aws_dynamodb_table.messages.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "step_function_sns" {
+  name = "${var.project_name}-step-function-sns"
+  role = aws_iam_role.step_function_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["sns:Publish"]
+        Resource = [
+          aws_sns_topic.bad_message_notifications.arn,
+          aws_sns_topic.dlq_notifications.arn
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_sfn_state_machine" "message_processor" {
+  name     = "${var.project_name}-processor"
+  role_arn = aws_iam_role.step_function_role.arn
+  type     = "EXPRESS" # REQUEST_RESPONSE pipe invocation requires Express workflow
+
+  # EventBridge Pipe delivers SQS messages as an array (batch).
+  # The Map state iterates each message individually.
+  # Body arrives as a raw JSON string so States.StringToJson is required before
+  # accessing id/content.
+  definition = jsonencode({
+    Comment = "Process SQS message batch from EventBridge Pipe"
+    StartAt = "ProcessBatch"
+    States = {
+      ProcessBatch = {
+        Type          = "Map"
+        ItemsPath     = "$"
+        MaxConcurrency = 0
+        ItemProcessor = {
+          ProcessorConfig = {
+            Mode = "INLINE"
+          }
+          StartAt = "CheckTypeAttributePresent"
+          States = {
+
+            # Guard: check $.messageAttributes.type exists before reading its value.
+            CheckTypeAttributePresent = {
+              Type = "Choice"
+              Choices = [
+                {
+                  Variable  = "$.messageAttributes.type"
+                  IsPresent = false
+                  Next      = "SendBadMessageNotification"
+                }
+              ]
+              Default = "CheckMessageType"
+            }
+
+            CheckMessageType = {
+              Type = "Choice"
+              Choices = [
+                {
+                  Variable     = "$.messageAttributes.type.stringValue"
+                  StringEquals = "good"
+                  Next         = "ParseBody"
+                },
+                {
+                  Variable     = "$.messageAttributes.type.stringValue"
+                  StringEquals = "bad"
+                  Next         = "SendBadMessageNotification"
+                }
+              ]
+              Default = "SendBadMessageNotification"
+            }
+
+            # Parse the body string into an object so id/content are accessible.
+            ParseBody = {
+              Type = "Pass"
+              Parameters = {
+                "messageAttributes.$" = "$.messageAttributes"
+                "parsedBody.$"        = "States.StringToJson($.body)"
+              }
+              Next = "StoreGoodMessage"
+            }
+
+            StoreGoodMessage = {
+              Type     = "Task"
+              Resource = "arn:aws:states:::dynamodb:putItem"
+              Parameters = {
+                TableName = aws_dynamodb_table.messages.name
+                Item = {
+                  id = {
+                    # DynamoDB N type requires a string representation of the number.
+                    "N.$" = "States.Format('{}', $.parsedBody.id)"
+                  }
+                  content = {
+                    "S.$" = "$.parsedBody.content"
+                  }
+                  type = {
+                    S = "good"
+                  }
+                  processedAt = {
+                    "S.$" = "$$.State.EnteredTime"
+                  }
+                }
+              }
+              Next = "MessageProcessed"
+              Catch = [
+                {
+                  ErrorEquals = ["States.ALL"]
+                  Next        = "ProcessingError"
+                }
+              ]
+            }
+
+            SendBadMessageNotification = {
+              Type     = "Task"
+              Resource = "arn:aws:states:::sns:publish"
+              Parameters = {
+                TopicArn  = aws_sns_topic.bad_message_notifications.arn
+                Subject   = "Bad or Invalid Message Received"
+                "Message.$" = "$.body"
+              }
+              Next = "MessageProcessed"
+            }
+
+            ProcessingError = {
+              Type  = "Fail"
+              Error = "ProcessingFailed"
+              Cause = "DynamoDB write error"
+            }
+
+            MessageProcessed = {
+              Type = "Succeed"
+            }
+          }
+        }
+        Next = "BatchProcessed"
+      }
+
+      BatchProcessed = {
+        Type = "Succeed"
+      }
+    }
+  })
+
+  logging_configuration {
+    level                  = "ALL"
+    include_execution_data = true
+    log_destination        = "${aws_cloudwatch_log_group.sf_logs.arn}:*"
+  }
+
+  tags = {
+    Name = "${var.project_name}-step-function"
+  }
+
+  depends_on = [aws_iam_role_policy.step_function_logs]
+}

--- a/sns-sqs-eventbridge/terraform/terraform.tfvars.example
+++ b/sns-sqs-eventbridge/terraform/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Example Terraform variables - copy to terraform.tfvars and update values
+aws_region     = "ap-southeast-1"  # Singapore region
+project_name   = "trainee-rifat-message-processor"  # All resources will have this prefix
+environment    = "dev"
+admin_email    = "your-email@example.com"  # REQUIRED: Update this
+
+# SQS Configuration
+sqs_visibility_timeout = 30  # Messages are retried after 30 seconds
+max_receive_count      = 2   # After 2 failures, send to DLQ
+
+# EventBridge Pipe Configuration
+eventbridge_batch_size          = 5  # Process 5 messages at a time
+eventbridge_batching_window     = 0  # No wait between batches (immediate processing)

--- a/sns-sqs-eventbridge/terraform/variables.tf
+++ b/sns-sqs-eventbridge/terraform/variables.tf
@@ -1,0 +1,53 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "ap-southeast-1"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "trainee-rifat-message-processor"
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "admin_email" {
+  description = "Email address for SNS notifications (bad messages and DLQ alerts)"
+  type        = string
+  sensitive   = true
+}
+
+variable "sqs_visibility_timeout" {
+  description = "Visibility timeout for SQS messages in seconds"
+  type        = number
+  default     = 30
+}
+
+variable "max_receive_count" {
+  description = "Maximum number of times a message can be received before being sent to DLQ"
+  type        = number
+  default     = 2
+}
+
+variable "eventbridge_batch_size" {
+  description = "Batch size for EventBridge Pipe (max 10 for SQS)"
+  type        = number
+  default     = 5
+}
+
+variable "eventbridge_batching_window" {
+  description = "Maximum batching window in seconds"
+  type        = number
+  default     = 0
+}
+
+variable "enable_dynamodb_pitr" {
+  description = "Enable Point-in-Time Recovery for DynamoDB"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## SNS/SQS Message Processing System

Serverless AWS infrastructure that receives JSON messages from SQS, routes them based on a message attribute, stores valid messages in DynamoDB, and emails admins about bad or failed messages.


### Architecture

```
SQS Queue
  └─ EventBridge Pipe (batch: 5, REQUEST_RESPONSE)
       └─ Step Function (Express)
            ├─ type="good"           → DynamoDB
            ├─ type="bad"            → SNS → email
            └─ missing/invalid type  → SNS → email

Retry / failure path:
  SQS retries failed message after 30s
  After 2 failures → DLQ
  DLQ → EventBridge Pipe (batch: 1) → SNS → email (message deleted from DLQ after send)
```

### AWS Resources

**Region:** Singapore (ap-southeast-1)  

| Resource | Name |
|---|---|
| SQS Queue | `trainee-rifat-message-processor-queue` |
| SQS DLQ | `trainee-rifat-message-processor-dlq` |
| EventBridge Pipe (main) | `trainee-rifat-message-processor-sqs-to-sf` |
| EventBridge Pipe (DLQ) | `trainee-rifat-message-processor-dlq-to-sns` |
| Step Function | `trainee-rifat-message-processor-processor` |
| DynamoDB Table | `trainee-rifat-message-processor-messages` |
| SNS (bad messages) | `trainee-rifat-message-processor-bad-message-notifications` |
| SNS (DLQ alerts) | `trainee-rifat-message-processor-dlq-notifications` |

---

### Message Format

**Body** (JSON string):
```json
{ "id": 1, "content": "your message" }
```

**Message attribute** `type` (String): `"good"` , `"bad"` or anything invalid. The `type` field is a **message attribute**, not part of the body.

---

### Deploy

```bash
cd terraform
cp terraform.tfvars.example terraform.tfvars
# Set admin_email in terraform.tfvars

terraform init
terraform apply
```

After apply, check inbox and **confirm both SNS subscription emails** before testing — emails won't arrive until confirmed.

---

### Send Test Messages

```bash
QUEUE_URL=$(terraform output -raw sqs_main_queue_url)

# Good message → stored in DynamoDB
aws sqs send-message \
  --queue-url $QUEUE_URL \
  --message-body '{"id": 1, "content": "hello"}' \
  --message-attributes '{"type": {"DataType": "String", "StringValue": "good"}}' \
  --region ap-southeast-1

# Bad message → email alert
aws sqs send-message \
  --queue-url $QUEUE_URL \
  --message-body '{"id": 2, "content": "hello"}' \
  --message-attributes '{"type": {"DataType": "String", "StringValue": "bad"}}' \
  --region ap-southeast-1

# Missing type attribute → email alert
aws sqs send-message \
  --queue-url $QUEUE_URL \
  --message-body '{"id": 3, "content": "hello"}' \
  --region ap-southeast-1

# Invalid body (triggers retry → DLQ → email after ~60s)
aws sqs send-message \
  --queue-url $QUEUE_URL \
  --message-body 'NOT JSON' \
  --message-attributes '{"type": {"DataType": "String", "StringValue": "good"}}' \
  --region ap-southeast-1
```

---

### Verify Results

```bash
cd terraform

# Check DynamoDB for stored good messages
aws dynamodb scan \
  --table-name $(terraform output -raw dynamodb_table_name) \
  --region ap-southeast-1

# Check DLQ message count
aws sqs get-queue-attributes \
  --queue-url $(terraform output -raw sqs_dlq_url) \
  --attribute-names ApproximateNumberOfMessages \
  --region ap-southeast-1
```

---

### Logs

| What | Where |
|---|---|
| Pipe (main) execution details | CloudWatch → `/aws/pipes/trainee-rifat-message-processor-sqs-to-sf` |
| Pipe (DLQ) execution details | CloudWatch → `/aws/pipes/trainee-rifat-message-processor-dlq-to-sns` |
| Step Function state transitions | CloudWatch → `/aws/states/trainee-rifat-message-processor-processor` |

> Step Function executions are **not** visible in the SF console (Express workflow) — CloudWatch logs are the only view.

---

### Configuration

Edit `terraform/terraform.tfvars`:

| Variable | Default | Description |
|---|---|---|
| `admin_email` | — | **Required.** Email for all SNS alerts |
| `aws_region` | `ap-southeast-1` | AWS region |
| `sqs_visibility_timeout` | `30` | Seconds before a failed message is retried |
| `max_receive_count` | `2` | Failures before message moves to DLQ |
| `eventbridge_batch_size` | `5` | Messages per SF invocation (max 10) |

---

### Cost Estimate

All resources are pay-per-use. No idle cost.

| Service | Pricing |
|---|---|
| SQS | $0.40 / million requests |
| EventBridge Pipe | $0.35 / DPU-hour |
| Step Functions (Express) | $1.00 / million executions + $0.00001 / state transition |
| DynamoDB | $1.25 / million write units |
| SNS | $0.50 / million notifications |

---

### Cleanup

```bash
cd terraform
terraform destroy
```
