### PR TITLE
Wire Authentication and CSRF token to frontend project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ meal-planner-task2/
 async-ui-react-query/
 .vercel/
 .env.local
+form-validation/
+sns-sqs-eventbridge/

--- a/routing-and-security/.gitignore
+++ b/routing-and-security/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+CLAUDE.md

--- a/routing-and-security/index.html
+++ b/routing-and-security/index.html
@@ -1,0 +1,13 @@
+<!-- index.html -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend Security & Routing Training</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/routing-and-security/package-lock.json
+++ b/routing-and-security/package-lock.json
@@ -1,0 +1,1756 @@
+{
+  "name": "routing-security-training",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "routing-security-training",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.43",
+        "@types/react-dom": "^18.2.17",
+        "@vitejs/plugin-react": "^4.2.1",
+        "vite": "^5.0.8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.355",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
+      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/routing-and-security/package.json
+++ b/routing-and-security/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "routing-security-training",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.43",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.0.8"
+  }
+}

--- a/routing-and-security/server/index.js
+++ b/routing-and-security/server/index.js
@@ -1,0 +1,43 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
+
+const app = express();
+app.use(express.json());
+
+const JWT_SECRET = 'routing-security-demo-secret';
+const HARDCODED_USER = { email: 'demo@example.com', password: 'password123' };
+
+// In-memory store of valid CSRF tokens (single-use)
+const csrfTokens = new Set();
+
+// POST /api/login — validate hardcoded credentials, return JWT
+app.post('/api/login', (req, res) => {
+  const { email, password } = req.body ?? {};
+  if (email === HARDCODED_USER.email && password === HARDCODED_USER.password) {
+    const token = jwt.sign({ email }, JWT_SECRET, { expiresIn: '1h' });
+    return res.json({ token });
+  }
+  return res.status(401).json({ error: 'Invalid credentials' });
+});
+
+// GET /api/csrf-token — issue a new CSRF token and store it server-side
+app.get('/api/csrf-token', (req, res) => {
+  const csrfToken = randomUUID();
+  csrfTokens.add(csrfToken);
+  res.json({ csrfToken });
+});
+
+// POST /api/transfer — state-changing endpoint; rejects requests with missing/invalid CSRF token
+app.post('/api/transfer', (req, res) => {
+  const provided = req.headers['x-csrf-token'];
+  if (!provided || !csrfTokens.has(provided)) {
+    return res.status(403).json({ ok: false, reason: 'Blocked: missing or invalid CSRF token.' });
+  }
+  csrfTokens.delete(provided); // single-use: consumed after first valid request
+  return res.json({ ok: true, reason: 'Success: transfer accepted (valid CSRF token).' });
+});
+
+app.listen(3001, () => {
+  console.log('Backend running on http://localhost:3001');
+});

--- a/routing-and-security/server/index.js
+++ b/routing-and-security/server/index.js
@@ -21,8 +21,21 @@ app.post('/api/login', (req, res) => {
   return res.status(401).json({ error: 'Invalid credentials' });
 });
 
-// GET /api/csrf-token — issue a new CSRF token and store it server-side
-app.get('/api/csrf-token', (req, res) => {
+// Middleware: verify JWT from Authorization header
+function requireAuth(req, res, next) {
+  const auth = req.headers['authorization'] ?? '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+  if (!token) return res.status(401).json({ error: 'Missing token' });
+  try {
+    jwt.verify(token, JWT_SECRET);
+    next();
+  } catch {
+    return res.status(401).json({ error: 'Invalid or expired token' });
+  }
+}
+
+// GET /api/csrf-token — issue a new CSRF token; requires valid JWT session
+app.get('/api/csrf-token', requireAuth, (req, res) => {
   const csrfToken = randomUUID();
   csrfTokens.add(csrfToken);
   res.json({ csrfToken });

--- a/routing-and-security/server/package-lock.json
+++ b/routing-and-security/server/package-lock.json
@@ -1,0 +1,946 @@
+{
+  "name": "routing-security-server",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "routing-security-server",
+      "version": "0.0.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/routing-and-security/server/package.json
+++ b/routing-and-security/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "routing-security-server",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/routing-and-security/src/App.jsx
+++ b/routing-and-security/src/App.jsx
@@ -1,0 +1,52 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Layout from './components/Layout';
+import ProtectedRoute from './components/ProtectedRoute';
+
+import Intro from './routes/Intro';
+import RoutingBasics from './routes/RoutingBasics';
+import ParamsDemo from './routes/ParamsDemo';
+import ProtectedRoutesExplanation from './routes/ProtectedRoutesExplanation';
+import DemoApp from './routes/DemoApp';
+import XSSDemo from './routes/XSSDemo';
+import StorageDemo from './routes/StorageDemo';
+import AdminPage from './routes/AdminPage';
+
+function NotFound() {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '4rem' }}>
+      <h1>404 — Page Not Found</h1>
+      <p>This route doesn't exist. Use the navbar to navigate.</p>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Intro />} />
+          <Route path="/routing" element={<RoutingBasics />} />
+          <Route path="/params/:userId" element={<ParamsDemo />} />
+          <Route path="/protected" element={<ProtectedRoutesExplanation />} />
+          <Route path="/demo" element={<DemoApp />} />
+          <Route path="/xss" element={<XSSDemo />} />
+          <Route path="/storage" element={<StorageDemo />} />
+          {/* Protected route example: /admin requires login */}
+          <Route
+            path="/admin"
+            element={
+              <ProtectedRoute>
+                <AdminPage />
+              </ProtectedRoute>
+            }
+          />
+          {/* Catch-all: any unknown URL shows 404 */}
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/routing-and-security/src/components/Layout.jsx
+++ b/routing-and-security/src/components/Layout.jsx
@@ -1,0 +1,37 @@
+import Navbar from './Navbar';
+
+function Layout({ children }) {
+  return (
+    <div style={styles.container}>
+      <Navbar />
+      <main style={styles.main}>{children}</main>
+      <footer style={styles.footer}>
+        <small>Training app: routing, security & best practices</small>
+      </footer>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  main: {
+    flex: 1,
+    padding: '2rem',
+    maxWidth: '1200px',
+    margin: '0 auto',
+    width: '100%',
+  },
+  footer: {
+    textAlign: 'center',
+    padding: '1rem',
+    backgroundColor: '#ecf0f1',
+    fontSize: '0.8rem',
+  },
+};
+
+export default Layout;

--- a/routing-and-security/src/components/Navbar.jsx
+++ b/routing-and-security/src/components/Navbar.jsx
@@ -1,0 +1,53 @@
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const navLinkStyle = ({ isActive }) => ({
+  color: 'white',
+  textDecoration: 'none',
+  fontWeight: '500',
+  padding: '0.25rem 0.5rem',
+  borderRadius: '4px',
+  background: isActive ? '#1abc9c' : 'transparent',
+  outline: isActive ? '2px solid #1abc9c' : 'none',
+});
+
+function Navbar() {
+  const { isLoggedIn } = useAuth();
+  return (
+    <nav style={styles.nav}>
+      <NavLink to="/" end style={navLinkStyle}>Intro</NavLink>
+      <NavLink to="/routing" style={navLinkStyle}>Routing</NavLink>
+      <NavLink to="/params/42" style={navLinkStyle}>Params/Query</NavLink>
+      <NavLink to="/protected" style={navLinkStyle}>Protected</NavLink>
+      <NavLink to="/demo" style={navLinkStyle}>Demo App</NavLink>
+      <NavLink to="/xss" style={navLinkStyle}>XSS+CSRF</NavLink>
+      <NavLink to="/storage" style={navLinkStyle}>Storage</NavLink>
+      <NavLink to="/admin" style={navLinkStyle}>Admin (protected)</NavLink>
+      <span style={styles.authBadge}>
+        {isLoggedIn ? '✅ Logged in' : '🔒 Not logged in'}
+      </span>
+    </nav>
+  );
+}
+
+const styles = {
+  nav: {
+    background: '#2c3e50',
+    padding: '0.75rem 1rem',
+    display: 'flex',
+    gap: '1rem',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    borderBottom: '2px solid #ecf0f1',
+  },
+  authBadge: {
+    marginLeft: 'auto',
+    background: '#1abc9c',
+    padding: '0.25rem 0.75rem',
+    borderRadius: '20px',
+    fontSize: '0.8rem',
+    color: '#fff',
+  },
+};
+
+export default Navbar;

--- a/routing-and-security/src/components/ProtectedRoute.jsx
+++ b/routing-and-security/src/components/ProtectedRoute.jsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+function ProtectedRoute({ children }) {
+  const { isLoggedIn } = useAuth();
+
+  if (!isLoggedIn) {
+    // Redirect to the demo page where the user can log in
+    return <Navigate to="/demo" replace />;
+  }
+
+  return children;
+}
+
+export default ProtectedRoute;

--- a/routing-and-security/src/components/ProtectedRoute.jsx
+++ b/routing-and-security/src/components/ProtectedRoute.jsx
@@ -1,12 +1,13 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 function ProtectedRoute({ children }) {
   const { isLoggedIn } = useAuth();
+  const location = useLocation();
 
   if (!isLoggedIn) {
-    // Redirect to the demo page where the user can log in
-    return <Navigate to="/demo" replace />;
+    // Pass the attempted URL in router state so DemoApp can redirect back after login
+    return <Navigate to="/demo" state={{ from: location.pathname }} replace />;
   }
 
   return children;

--- a/routing-and-security/src/context/AuthContext.jsx
+++ b/routing-and-security/src/context/AuthContext.jsx
@@ -3,41 +3,57 @@ import { createContext, useContext, useState } from 'react';
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
-  // Mock auth state - stored in React state (in-memory, not persistent)
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [token, setToken] = useState(null);
+  const [csrfToken, setCsrfToken] = useState(null);
 
-  // Fake login function (no backend)
-  const login = (email, password) => {
-    // Simulate API call - accept any non-empty credentials
-    if (email && password) {
+  // Calls POST /api/login with real credentials.
+  // On success, fetches a CSRF token and stores both in memory.
+  // Returns { ok: true } or { ok: false, error: string }.
+  const login = async (email, password) => {
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!res.ok) {
+        const { error } = await res.json();
+        return { ok: false, error: error ?? 'Invalid credentials' };
+      }
+
+      const { token: jwt } = await res.json();
+
+      // Fetch a CSRF token immediately after login so it is ready for
+      // any subsequent state-changing requests in this session.
+      const csrfRes = await fetch('/api/csrf-token');
+      const { csrfToken: csrf } = await csrfRes.json();
+
+      setToken(jwt);
+      setCsrfToken(csrf);
       setIsLoggedIn(true);
-      setToken('fake-jwt-token-' + Date.now());
-      return true;
+      return { ok: true };
+    } catch {
+      return { ok: false, error: 'Network error — is the backend running?' };
     }
-    return false;
   };
 
   const logout = () => {
     setIsLoggedIn(false);
     setToken(null);
+    setCsrfToken(null);
   };
 
-  const value = {
-    isLoggedIn,
-    token,
-    login,
-    logout,
-  };
-
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={{ isLoggedIn, token, csrfToken, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
 }
 
-// Custom hook to use auth context
 export function useAuth() {
   const context = useContext(AuthContext);
-  if (!context) {
-    throw new Error('useAuth must be used within AuthProvider');
-  }
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
   return context;
 }

--- a/routing-and-security/src/context/AuthContext.jsx
+++ b/routing-and-security/src/context/AuthContext.jsx
@@ -2,13 +2,13 @@ import { createContext, useContext, useState } from 'react';
 
 const AuthContext = createContext(null);
 
+const STORAGE_KEY = 'auth_token';
+
 export function AuthProvider({ children }) {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [token, setToken] = useState(null);
-  const [csrfToken, setCsrfToken] = useState(null);
+  const [token, setToken] = useState(() => sessionStorage.getItem(STORAGE_KEY));
+  const [isLoggedIn, setIsLoggedIn] = useState(() => !!sessionStorage.getItem(STORAGE_KEY));
 
   // Calls POST /api/login with real credentials.
-  // On success, fetches a CSRF token and stores both in memory.
   // Returns { ok: true } or { ok: false, error: string }.
   const login = async (email, password) => {
     try {
@@ -25,13 +25,8 @@ export function AuthProvider({ children }) {
 
       const { token: jwt } = await res.json();
 
-      // Fetch a CSRF token immediately after login so it is ready for
-      // any subsequent state-changing requests in this session.
-      const csrfRes = await fetch('/api/csrf-token');
-      const { csrfToken: csrf } = await csrfRes.json();
-
+      sessionStorage.setItem(STORAGE_KEY, jwt);
       setToken(jwt);
-      setCsrfToken(csrf);
       setIsLoggedIn(true);
       return { ok: true };
     } catch {
@@ -40,13 +35,13 @@ export function AuthProvider({ children }) {
   };
 
   const logout = () => {
+    sessionStorage.removeItem(STORAGE_KEY);
     setIsLoggedIn(false);
     setToken(null);
-    setCsrfToken(null);
   };
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, token, csrfToken, login, logout }}>
+    <AuthContext.Provider value={{ isLoggedIn, token, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/routing-and-security/src/context/AuthContext.jsx
+++ b/routing-and-security/src/context/AuthContext.jsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  // Mock auth state - stored in React state (in-memory, not persistent)
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [token, setToken] = useState(null);
+
+  // Fake login function (no backend)
+  const login = (email, password) => {
+    // Simulate API call - accept any non-empty credentials
+    if (email && password) {
+      setIsLoggedIn(true);
+      setToken('fake-jwt-token-' + Date.now());
+      return true;
+    }
+    return false;
+  };
+
+  const logout = () => {
+    setIsLoggedIn(false);
+    setToken(null);
+  };
+
+  const value = {
+    isLoggedIn,
+    token,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+// Custom hook to use auth context
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}

--- a/routing-and-security/src/main.jsx
+++ b/routing-and-security/src/main.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import { AuthProvider } from './context/AuthContext';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </React.StrictMode>
+);

--- a/routing-and-security/src/routes/AdminPage.jsx
+++ b/routing-and-security/src/routes/AdminPage.jsx
@@ -1,0 +1,32 @@
+import { useAuth } from '../context/AuthContext';
+
+function AdminPage() {
+  const { token } = useAuth();
+  return (
+    <div>
+      <h1>👑 Admin Panel (Protected Route)</h1>
+      <div style={styles.card}>
+        <p>You have accessed the protected admin area because you are authenticated.</p>
+        <div style={styles.infoBox}>
+          <strong>Current session token:</strong> <code>{token}</code>
+        </div>
+        <h3>Admin Actions (Demo)</h3>
+        <ul>
+          <li>📋 Manage users (simulated)</li>
+          <li>⚙️ System configuration</li>
+          <li>📊 View analytics</li>
+        </ul>
+        <p style={{ marginTop: '1rem', fontSize: '0.9rem', background: '#fff3cd', padding: '0.5rem' }}>
+          🔐 This page is protected by <code>ProtectedRoute</code>. Try logging out from the Demo App and refresh.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  card: { background: '#f8f9fa', padding: '1.5rem', borderRadius: '8px' },
+  infoBox: { background: '#e2e3e5', padding: '0.75rem', borderRadius: '4px', margin: '1rem 0' },
+};
+
+export default AdminPage;

--- a/routing-and-security/src/routes/DemoApp.jsx
+++ b/routing-and-security/src/routes/DemoApp.jsx
@@ -1,10 +1,13 @@
 import { useAuth } from '../context/AuthContext';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useState } from 'react';
 
 function DemoApp() {
   const { isLoggedIn, token, login, logout } = useAuth();
-  const navigate = useNavigate(); // useNavigate for programmatic navigation
+  const navigate = useNavigate();
+  const location = useLocation();
+  // ProtectedRoute sets state.from to the URL the user originally tried to visit
+  const intendedPath = location.state?.from ?? null;
   const [email, setEmail] = useState('demo@example.com');
   const [password, setPassword] = useState('password123');
   const [loginError, setLoginError] = useState('');
@@ -15,7 +18,8 @@ function DemoApp() {
       setLoginError(error ?? 'Login failed');
     } else {
       setLoginError('');
-      navigate('/demo');
+      // Navigate back to the page the user was trying to reach, or stay on /demo
+      navigate(intendedPath ?? '/demo', { replace: true });
     }
   };
 
@@ -27,6 +31,11 @@ function DemoApp() {
           <div style={styles.loginBox}>
             <h3>Login</h3>
             <p>Credentials are validated against the backend (demo@example.com / password123)</p>
+            {intendedPath && (
+              <p style={{ background: '#fff3cd', padding: '0.4rem 0.6rem', borderRadius: '4px', fontSize: '0.85rem' }}>
+                You will be redirected to <code>{intendedPath}</code> after login.
+              </p>
+            )}
             <input
               type="email"
               placeholder="Email"

--- a/routing-and-security/src/routes/DemoApp.jsx
+++ b/routing-and-security/src/routes/DemoApp.jsx
@@ -1,0 +1,92 @@
+import { useAuth } from '../context/AuthContext';
+import { Link, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+
+function DemoApp() {
+  const { isLoggedIn, token, login, logout } = useAuth();
+  const navigate = useNavigate(); // useNavigate for programmatic navigation
+  const [email, setEmail] = useState('demo@example.com');
+  const [password, setPassword] = useState('password123');
+  const [loginError, setLoginError] = useState('');
+
+  const handleLogin = () => {
+    const success = login(email, password);
+    if (!success) {
+      setLoginError('Please enter email and password');
+    } else {
+      setLoginError('');
+      // Programmatic navigation after login — same as useNavigate('/dashboard')
+      navigate('/demo');
+    }
+  };
+
+  return (
+    <div>
+      <h1>🎮 Demo App: Authentication + Protected Area</h1>
+      <div style={styles.card}>
+        {!isLoggedIn ? (
+          <div style={styles.loginBox}>
+            <h3>Login (Mock Auth)</h3>
+            <p>Enter any email/password to simulate login</p>
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              style={styles.input}
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              style={styles.input}
+            />
+            <button onClick={handleLogin} style={styles.button}>
+              Login
+            </button>
+            {loginError && <p style={{ color: 'red' }}>{loginError}</p>}
+          </div>
+        ) : (
+          <div>
+            <div style={styles.loggedBox}>
+              <h3>✅ You are logged in!</h3>
+              <p><strong>Mock token:</strong> {token}</p>
+              <button onClick={logout} style={styles.button}>Logout</button>
+            </div>
+
+            <hr />
+            <h3>Dashboard (accessible to any logged-in user)</h3>
+            <div style={styles.dashboard}>
+              <p>📊 Welcome to your dashboard. Here is some statistics (demo).</p>
+              <p>🔐 Your role: <strong>Trainer</strong></p>
+            </div>
+
+            <hr />
+            <h3>Admin Section (Protected)</h3>
+            <div style={styles.adminLinkBox}>
+              <p>Admin page requires authentication (already satisfied).</p>
+              <Link to="/admin" style={styles.linkButton}>Go to Admin Panel →</Link>
+              <p style={{ fontSize: '0.9rem', marginTop: '0.5rem' }}>
+                💡 Try manually typing <code>/admin</code> in URL while logged out → redirects here.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  card: { background: '#f8f9fa', padding: '1.5rem', borderRadius: '8px' },
+  loginBox: { padding: '1rem', background: '#e9ecef', borderRadius: '6px' },
+  loggedBox: { background: '#d4edda', padding: '1rem', borderRadius: '6px' },
+  dashboard: { background: '#fff', padding: '1rem', border: '1px solid #dee2e6', borderRadius: '6px' },
+  adminLinkBox: { background: '#cfe2ff', padding: '1rem', borderRadius: '6px' },
+  input: { display: 'block', margin: '0.5rem 0', padding: '0.5rem', width: '250px' },
+  button: { padding: '0.5rem 1rem', cursor: 'pointer', background: '#007bff', color: '#fff', border: 'none', borderRadius: '4px' },
+  linkButton: { display: 'inline-block', marginTop: '0.5rem', padding: '0.4rem 0.8rem', background: '#28a745', color: 'white', textDecoration: 'none', borderRadius: '4px' },
+};
+
+export default DemoApp;

--- a/routing-and-security/src/routes/DemoApp.jsx
+++ b/routing-and-security/src/routes/DemoApp.jsx
@@ -9,13 +9,12 @@ function DemoApp() {
   const [password, setPassword] = useState('password123');
   const [loginError, setLoginError] = useState('');
 
-  const handleLogin = () => {
-    const success = login(email, password);
-    if (!success) {
-      setLoginError('Please enter email and password');
+  const handleLogin = async () => {
+    const { ok, error } = await login(email, password);
+    if (!ok) {
+      setLoginError(error ?? 'Login failed');
     } else {
       setLoginError('');
-      // Programmatic navigation after login — same as useNavigate('/dashboard')
       navigate('/demo');
     }
   };
@@ -26,8 +25,8 @@ function DemoApp() {
       <div style={styles.card}>
         {!isLoggedIn ? (
           <div style={styles.loginBox}>
-            <h3>Login (Mock Auth)</h3>
-            <p>Enter any email/password to simulate login</p>
+            <h3>Login</h3>
+            <p>Credentials are validated against the backend (demo@example.com / password123)</p>
             <input
               type="email"
               placeholder="Email"
@@ -51,7 +50,7 @@ function DemoApp() {
           <div>
             <div style={styles.loggedBox}>
               <h3>✅ You are logged in!</h3>
-              <p><strong>Mock token:</strong> {token}</p>
+              <p><strong>JWT:</strong> <span style={{ wordBreak: 'break-all', fontSize: '0.8rem' }}>{token}</span></p>
               <button onClick={logout} style={styles.button}>Logout</button>
             </div>
 

--- a/routing-and-security/src/routes/Intro.jsx
+++ b/routing-and-security/src/routes/Intro.jsx
@@ -1,0 +1,167 @@
+import { Link } from 'react-router-dom';
+
+const routes = [
+  {
+    path: '/',
+    label: 'Intro',
+    badge: 'Concept',
+    time: '0–5 min',
+    desc: 'Session overview and app structure.',
+  },
+  {
+    path: '/routing',
+    label: 'Routing Basics',
+    badge: 'Concept',
+    time: '5–15 min',
+    desc: 'BrowserRouter, Link, useLocation, client-side navigation.',
+  },
+  {
+    path: '/params/42',
+    label: 'Params & Query',
+    badge: 'Demo',
+    time: '15–25 min',
+    desc: 'useParams (:userId) and useSearchParams (?tab=).',
+  },
+  {
+    path: '/protected',
+    label: 'Protected Routes',
+    badge: 'Concept',
+    time: '25–35 min',
+    desc: 'ProtectedRoute component, Navigate redirect pattern.',
+  },
+  {
+    path: '/demo',
+    label: 'Demo App',
+    badge: 'Demo',
+    time: '35–45 min',
+    desc: 'Mock login, useNavigate after login, /admin redirect.',
+  },
+  {
+    path: '/xss',
+    label: 'XSS + CSRF',
+    badge: 'Security',
+    time: '45–55 min',
+    desc: 'dangerouslySetInnerHTML vs safe rendering, CSRF token sim.',
+  },
+  {
+    path: '/storage',
+    label: 'Token Storage',
+    badge: 'Security',
+    time: '55–60 min',
+    desc: 'localStorage vs cookie vs in-memory: trade-offs.',
+  },
+  {
+    path: '/admin',
+    label: 'Admin (protected)',
+    badge: 'Auth',
+    time: '—',
+    desc: 'Only reachable when logged in. Try it without logging in!',
+  },
+];
+
+const badgeColors = {
+  Concept: { background: '#dbeafe', color: '#1e40af' },
+  Demo: { background: '#dcfce7', color: '#166534' },
+  Security: { background: '#fee2e2', color: '#991b1b' },
+  Auth: { background: '#fef3c7', color: '#92400e' },
+};
+
+function Intro() {
+  return (
+    <div>
+      <h1>📖 Frontend Training: Routing & Security</h1>
+      <div style={styles.card}>
+        <p style={{ marginBottom: '0.75rem' }}>
+          This interactive app teaches React Router v6 and frontend security
+          through live demos. Use the <strong>navbar above</strong> to navigate
+          — each page is one "slide".
+        </p>
+        <p>
+          🔐 The <strong>Admin</strong> page is protected — try visiting it
+          without logging in!
+        </p>
+      </div>
+
+      <h2 style={{ marginTop: '1.5rem', marginBottom: '0.75rem' }}>
+        📋 Route Map
+      </h2>
+      <table style={styles.table}>
+        <thead>
+          <tr style={styles.thead}>
+            <th style={styles.th}>Path</th>
+            <th style={styles.th}>Page</th>
+            <th style={styles.th}>Type</th>
+            <th style={styles.th}>Time</th>
+            <th style={styles.th}>What you'll learn</th>
+          </tr>
+        </thead>
+        <tbody>
+          {routes.map((r) => (
+            <tr key={r.path} style={styles.tr}>
+              <td style={styles.tdMono}>
+                <Link to={r.path} style={styles.pathLink}>
+                  {r.path}
+                </Link>
+              </td>
+              <td style={styles.td}>{r.label}</td>
+              <td style={styles.td}>
+                <span style={{ ...styles.badge, ...badgeColors[r.badge] }}>
+                  {r.badge}
+                </span>
+              </td>
+              <td
+                style={{ ...styles.td, whiteSpace: 'nowrap', color: '#6b7280' }}
+              >
+                {r.time}
+              </td>
+              <td style={styles.td}>{r.desc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const styles = {
+  card: {
+    background: '#f8f9fa',
+    padding: '1.25rem',
+    borderRadius: '8px',
+    border: '1px solid #dee2e6',
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    background: '#fff',
+    border: '1px solid #dee2e6',
+    borderRadius: '8px',
+    overflow: 'hidden',
+    fontSize: '0.9rem',
+  },
+  thead: { background: '#2c3e50' },
+  th: {
+    color: 'white',
+    padding: '0.65rem 0.9rem',
+    textAlign: 'left',
+    fontWeight: 600,
+  },
+  tr: { borderBottom: '1px solid #dee2e6' },
+  td: { padding: '0.6rem 0.9rem', verticalAlign: 'top' },
+  tdMono: {
+    padding: '0.6rem 0.9rem',
+    fontFamily: 'monospace',
+    fontSize: '0.85rem',
+  },
+  pathLink: { color: '#1d4ed8', textDecoration: 'none', fontWeight: 500 },
+  badge: {
+    display: 'inline-block',
+    padding: '2px 8px',
+    borderRadius: '12px',
+    fontSize: '0.75rem',
+    fontWeight: 600,
+    whiteSpace: 'nowrap',
+  },
+};
+
+export default Intro;

--- a/routing-and-security/src/routes/ParamsDemo.jsx
+++ b/routing-and-security/src/routes/ParamsDemo.jsx
@@ -1,0 +1,217 @@
+import { useMemo } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+
+function ParamsDemo() {
+  const { userId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = searchParams.get('tab') || 'profile';
+  const sort = searchParams.get('sort') || 'recent';
+  const page = Number(searchParams.get('page') || 1);
+  const view = searchParams.get('view') || 'table';
+  const q = searchParams.get('q') || '';
+
+  const fullUrl = useMemo(() => {
+    const query = searchParams.toString();
+    return `/params/${userId}${query ? `?${query}` : ''}`;
+  }, [searchParams, userId]);
+
+  const updateQuery = (updates) => {
+    const next = new URLSearchParams(searchParams);
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value === '' || value === null || value === undefined) {
+        next.delete(key);
+      } else {
+        next.set(key, String(value));
+      }
+    });
+    setSearchParams(next);
+  };
+
+  const changeTab = (newTab) => {
+    // Reset page when moving to a new tab so pagination does not look broken.
+    updateQuery({ tab: newTab, page: 1 });
+  };
+
+  const nextPage = () => {
+    updateQuery({ page: page + 1 });
+  };
+
+  const prevPage = () => {
+    if (page > 1) {
+      updateQuery({ page: page - 1 });
+    }
+  };
+
+  const clearOptionalFilters = () => {
+    updateQuery({ q: '', sort: null });
+  };
+
+  return (
+    <div>
+      <h1>🔢 Route Params & Query Strings</h1>
+      <div style={styles.card}>
+        <p style={styles.helperText}>
+          In production apps, route params identify the resource (which user/project),
+          and query params capture UI state (tab, sort, pagination, search). This makes
+          the view shareable and reproducible.
+        </p>
+
+        <div style={styles.paramBox}>
+          <strong>Route param (:userId):</strong> <code>{userId}</code>
+          <br />
+          <small>Extracted using <code>useParams()</code> and usually maps to API/resource identity.</small>
+        </div>
+
+        <div style={styles.queryBox}>
+          <strong>Current URL:</strong> <code>{fullUrl}</code>
+          <br />
+          <strong>Resolved state:</strong>
+          <ul style={styles.stateList}>
+            <li><code>tab</code>: {tab}</li>
+            <li><code>sort</code>: {sort}</li>
+            <li><code>page</code>: {page}</li>
+            <li><code>view</code>: {view}</li>
+            <li><code>q</code>: {q || '(empty)'}</li>
+          </ul>
+        </div>
+
+        <div style={styles.controlsBox}>
+          <h4>Tab (query param)</h4>
+          <div style={styles.btnRow}>
+            <button onClick={() => changeTab('profile')} style={styles.btn}>
+              tab=profile
+            </button>
+            <button onClick={() => changeTab('settings')} style={styles.btn}>
+              tab=settings
+            </button>
+            <button onClick={() => changeTab('billing')} style={styles.btn}>
+              tab=billing
+            </button>
+          </div>
+
+          <h4 style={styles.subTitle}>Sort + View</h4>
+          <div style={styles.btnRow}>
+            <button onClick={() => updateQuery({ sort: 'recent' })} style={styles.btn}>sort=recent</button>
+            <button onClick={() => updateQuery({ sort: 'oldest' })} style={styles.btn}>sort=oldest</button>
+            <button onClick={() => updateQuery({ view: 'table' })} style={styles.btn}>view=table</button>
+            <button onClick={() => updateQuery({ view: 'card' })} style={styles.btn}>view=card</button>
+          </div>
+
+          <h4 style={styles.subTitle}>Pagination</h4>
+          <div style={styles.btnRow}>
+            <button onClick={prevPage} style={styles.btn} disabled={page <= 1}>Previous page</button>
+            <button onClick={nextPage} style={styles.btn}>Next page</button>
+          </div>
+
+          <h4 style={styles.subTitle}>Search Filter</h4>
+          <div style={styles.btnRow}>
+            <button onClick={() => updateQuery({ q: 'invoice' })} style={styles.btn}>q=invoice</button>
+            <button onClick={() => updateQuery({ q: 'failed-payment' })} style={styles.btn}>q=failed-payment</button>
+            <button onClick={() => updateQuery({ q: '' })} style={styles.btn}>clear q</button>
+          </div>
+
+          <button onClick={clearOptionalFilters} style={styles.secondaryBtn}>
+            Clear optional filters (q, sort)
+          </button>
+        </div>
+
+        <div style={styles.exampleBox}>
+          <h4>Real-world URL examples</h4>
+          <ul>
+            <li><code>/params/123?tab=profile&sort=recent&page=1</code></li>
+            <li><code>/params/acme-finance?tab=billing&view=card&q=invoice</code></li>
+            <li><code>/params/8472?tab=settings&page=3&sort=oldest</code></li>
+          </ul>
+          <p style={styles.noteText}>
+            Tip: route param usually maps to resource identity. Query params should store UI controls that
+            users may share with teammates.
+          </p>
+          <p style={styles.quickLinks}>
+            Quick links:{' '}
+            <Link to="/params/123?tab=profile&sort=recent&page=1">User 123</Link>
+            {' | '}
+            <Link to="/params/8472?tab=billing&view=card&q=invoice">Billing case</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  card: {
+    background: '#f8f9fa',
+    padding: '1.5rem',
+    borderRadius: '8px',
+    border: '1px solid #dee2e6',
+  },
+  helperText: {
+    color: '#334155',
+    lineHeight: '1.5',
+    marginBottom: '1rem',
+  },
+  paramBox: {
+    background: '#e2e3e5',
+    padding: '1rem',
+    borderRadius: '4px',
+    marginBottom: '1rem',
+  },
+  queryBox: {
+    background: '#d1ecf1',
+    padding: '1rem',
+    borderRadius: '4px',
+    marginBottom: '1rem',
+  },
+  controlsBox: {
+    background: '#eef2ff',
+    padding: '1rem',
+    borderRadius: '4px',
+    marginBottom: '1rem',
+    border: '1px solid #c7d2fe',
+  },
+  stateList: {
+    marginTop: '0.5rem',
+    paddingLeft: '1.1rem',
+    lineHeight: '1.5',
+  },
+  btnRow: {
+    display: 'flex',
+    gap: '0.5rem',
+    flexWrap: 'wrap',
+    marginBottom: '0.75rem',
+  },
+  subTitle: {
+    marginTop: '0.35rem',
+    marginBottom: '0.35rem',
+  },
+  btn: {
+    padding: '0.35rem 0.8rem',
+    cursor: 'pointer',
+    border: '1px solid #94a3b8',
+    borderRadius: '5px',
+    background: '#ffffff',
+  },
+  secondaryBtn: {
+    marginTop: '0.25rem',
+    padding: '0.4rem 0.85rem',
+    cursor: 'pointer',
+    border: 'none',
+    borderRadius: '5px',
+    background: '#334155',
+    color: '#ffffff',
+  },
+  exampleBox: {
+    background: '#fff3cd',
+    padding: '1rem',
+    borderRadius: '4px',
+  },
+  noteText: {
+    marginTop: '0.6rem',
+    color: '#374151',
+  },
+  quickLinks: {
+    marginTop: '0.5rem',
+  },
+};
+
+export default ParamsDemo;

--- a/routing-and-security/src/routes/ProtectedRoutesExplanation.jsx
+++ b/routing-and-security/src/routes/ProtectedRoutesExplanation.jsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router-dom';
+
+function ProtectedRoutesExplanation() {
+  return (
+    <div>
+      <h1>🛡️ Protected Routes Explanation</h1>
+      <div style={styles.card}>
+        <p>
+          A <strong>protected route</strong> only allows access when the user is authenticated.
+          Otherwise, it redirects to a login page.
+        </p>
+        <h3>Implementation pattern (React Router v6):</h3>
+        <pre style={styles.codeBlock}>
+{`// ProtectedRoute component
+function ProtectedRoute({ children }) {
+  const { isLoggedIn } = useAuth();
+  if (!isLoggedIn) return <Navigate to="/login" />;
+  return children;
+}
+
+// Usage in route config:
+<Route path="/admin" element={
+  <ProtectedRoute>
+    <AdminPage />
+  </ProtectedRoute>
+} />`}
+        </pre>
+        <div style={styles.demoBox}>
+          <h4>🔐 Live example:</h4>
+          <p>
+            The <strong>/admin</strong> route in this app is protected.
+            <br />
+            👉 <Link to="/admin">Try accessing /admin now</Link> (will redirect if not logged in).
+          </p>
+          <p>
+            👉 Go to <Link to="/demo">/demo page</Link> to log in first, then try /admin again.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  card: { background: '#f8f9fa', padding: '1.5rem', borderRadius: '8px' },
+  codeBlock: {
+    background: '#2d2d2d',
+    color: '#f8f8f2',
+    padding: '1rem',
+    borderRadius: '6px',
+    overflowX: 'auto',
+    fontFamily: 'monospace',
+  },
+  demoBox: { background: '#e9ecef', padding: '1rem', marginTop: '1rem', borderRadius: '4px' },
+};
+
+export default ProtectedRoutesExplanation;

--- a/routing-and-security/src/routes/RoutingBasics.jsx
+++ b/routing-and-security/src/routes/RoutingBasics.jsx
@@ -1,0 +1,243 @@
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+
+function RoutingBasics() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const goToInvoice = () => {
+    // Simulates a support or notifications flow deep-linking to a specific entity.
+    navigate('/params/8472?tab=billing');
+  };
+
+  const goToAdminGuardDemo = () => {
+    // Demonstrates protected page access when typed directly in the URL bar.
+    navigate('/admin');
+  };
+
+  return (
+    <div>
+      <h1>🧭 Routing Basics</h1>
+      <div style={styles.card}>
+        <p style={styles.helperText}>
+          This page is about production-style routing decisions, not only "how
+          to click links". Think of routes as product contracts: stable URLs,
+          shareable state, and predictable access control.
+        </p>
+
+        <div style={styles.urlBox}>
+          <p>
+            <strong>Current URL:</strong> <code>{location.pathname}</code>
+          </p>
+          <p>
+            <strong>Full location:</strong>{' '}
+            <code>
+              {location.pathname}
+              {location.search}
+              {location.hash}
+            </code>
+          </p>
+        </div>
+
+        <h3 style={styles.sectionTitle}>Real-world routing examples</h3>
+        <div style={styles.grid}>
+          <div style={styles.exampleCard}>
+            <h4>SaaS dashboard routes</h4>
+            <p>
+              Keep URL hierarchy aligned to product areas so onboarding is
+              easier.
+            </p>
+            <pre style={styles.pre}>{`/dashboard
+/projects
+/projects/:projectId
+/projects/:projectId/settings`}</pre>
+          </div>
+
+          <div style={styles.exampleCard}>
+            <h4>Deep-link support workflow</h4>
+            <p>
+              Support can paste a URL to open the exact tab a user is seeing.
+            </p>
+            <pre style={styles.pre}>{`/params/8472?tab=billing
+/params/8472?tab=activity`}</pre>
+          </div>
+
+          <div style={styles.exampleCard}>
+            <h4>Access control by route</h4>
+            <p>
+              Public URLs stay open. Sensitive routes must pass through route
+              guards.
+            </p>
+            <pre style={styles.pre}>{`/demo        -> public login page
+/admin       -> protected route
+/storage     -> concept page (public)`}</pre>
+          </div>
+
+          <div style={styles.exampleCard}>
+            <h4>Predictable fallback behavior</h4>
+            <p>Unknown paths should render a useful 404, not a blank screen.</p>
+            <pre
+              style={styles.pre}
+            >{`<Route path="*" element={<NotFound />} />`}</pre>
+          </div>
+        </div>
+
+        <h3 style={styles.sectionTitle}>
+          How navigation works in React Router v6
+        </h3>
+        <p>Build intuition for when to use each API:</p>
+        <ul>
+          <li>
+            <code>&lt;Link to="/path" /&gt;</code>: user-driven navigation
+            (menus, cards, breadcrumbs).
+          </li>
+          <li>
+            <code>useNavigate()</code>: event-driven navigation (login success,
+            wizard next step, retry actions).
+          </li>
+          <li>
+            <code>useLocation()</code>: read current route for analytics, active
+            states, and debug tools.
+          </li>
+          <li>
+            <code>Navigate</code> component: guard/redirect logic in render tree
+            (auth and role checks).
+          </li>
+        </ul>
+
+        <h3 style={styles.sectionTitle}>Interactive scenarios</h3>
+        <div style={styles.demoBox}>
+          <h4 style={styles.demoHeading}>Scenario 1: Notification deep-link</h4>
+          <p>
+            Simulate clicking "Invoice overdue" notification and opening a
+            specific entity + tab.
+          </p>
+          <button style={styles.button} onClick={goToInvoice}>
+            Open invoice route (/params/8472?tab=billing)
+          </button>
+        </div>
+
+        <div style={styles.demoBox}>
+          <h4 style={styles.demoHeading}>
+            Scenario 2: Manual URL access to protected page
+          </h4>
+          <p>
+            Simulate a user typing <code>/admin</code> directly. Route guard
+            decides access.
+          </p>
+          <button style={styles.button} onClick={goToAdminGuardDemo}>
+            Try /admin now
+          </button>
+          <p style={styles.smallText}>
+            If logged out, you should be redirected to <code>/demo</code>.
+          </p>
+        </div>
+
+        <div style={styles.demoBox}>
+          <h4 style={styles.demoHeading}>
+            Scenario 3: Regular link navigation
+          </h4>
+          <p>All links below use client-side routing (no full page refresh):</p>
+          <div style={styles.linksRow}>
+            <Link to="/routing">Stay on routing</Link>
+            <Link to="/params/99?tab=profile">Go to params demo</Link>
+            <Link to="/demo">Go to demo app</Link>
+            <Link to="/xss">Go to security demo</Link>
+          </div>
+        </div>
+
+        <div style={styles.tipBox}>
+          <strong>Team guideline:</strong> Put shareable UI state in the URL
+          (path/query), and keep ephemeral state in memory. This improves
+          supportability, QA reproducibility, and analytics quality.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  card: {
+    background: '#f8f9fa',
+    padding: '1.5rem',
+    borderRadius: '8px',
+    border: '1px solid #dfe3e8',
+  },
+  helperText: {
+    marginBottom: '1rem',
+    color: '#334155',
+    lineHeight: '1.5',
+  },
+  sectionTitle: {
+    marginTop: '1.1rem',
+    marginBottom: '0.6rem',
+  },
+  urlBox: {
+    background: '#eef2ff',
+    border: '1px solid #c7d2fe',
+    borderRadius: '6px',
+    padding: '0.8rem',
+    marginBottom: '1rem',
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))',
+    gap: '0.8rem',
+    marginBottom: '1rem',
+  },
+  exampleCard: {
+    background: '#ffffff',
+    border: '1px solid #e5e7eb',
+    borderRadius: '6px',
+    padding: '0.85rem',
+    lineHeight: '1.45',
+  },
+  pre: {
+    marginTop: '0.55rem',
+    background: '#111827',
+    color: '#f3f4f6',
+    borderRadius: '6px',
+    padding: '0.6rem',
+    fontSize: '0.8rem',
+    overflowX: 'auto',
+  },
+  demoBox: {
+    background: '#eef2f7',
+    border: '1px solid #d5dee8',
+    padding: '1rem',
+    marginTop: '1rem',
+    borderRadius: '6px',
+  },
+  demoHeading: {
+    marginBottom: '0.45rem',
+  },
+  linksRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.9rem',
+    marginTop: '0.35rem',
+  },
+  button: {
+    marginTop: '0.35rem',
+    background: '#0f766e',
+    color: '#ffffff',
+    border: 'none',
+    borderRadius: '6px',
+    padding: '0.5rem 0.75rem',
+    cursor: 'pointer',
+  },
+  smallText: {
+    marginTop: '0.45rem',
+    color: '#475569',
+    fontSize: '0.9rem',
+  },
+  tipBox: {
+    marginTop: '1rem',
+    background: '#fff7ed',
+    border: '1px solid #fed7aa',
+    borderRadius: '6px',
+    padding: '0.85rem',
+    lineHeight: '1.5',
+  },
+};
+
+export default RoutingBasics;

--- a/routing-and-security/src/routes/StorageDemo.jsx
+++ b/routing-and-security/src/routes/StorageDemo.jsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react';
+
+function StorageDemo() {
+  // LocalStorage demo
+  const [localToken, setLocalToken] = useState('');
+  const [cookieToken, setCookieToken] = useState('');
+  const [memoryToken, setMemoryToken] = useState('');
+
+  // Load initial values
+  useEffect(() => {
+    const saved = localStorage.getItem('demo_token');
+    if (saved) setLocalToken(saved);
+    // Read mock cookie (document.cookie)
+    const match = document.cookie.match(/demo_cookie_token=([^;]+)/);
+    if (match) setCookieToken(match[1]);
+  }, []);
+
+  const saveToLocalStorage = () => {
+    const token = 'ls_token_' + Date.now();
+    localStorage.setItem('demo_token', token);
+    setLocalToken(token);
+  };
+
+  const saveToCookie = () => {
+    const token = 'cookie_token_' + Date.now();
+    document.cookie = `demo_cookie_token=${token}; path=/; max-age=3600`;
+    setCookieToken(token);
+  };
+
+  const saveToMemory = () => {
+    setMemoryToken('memory_token_' + Date.now());
+  };
+
+  const clearAll = () => {
+    localStorage.removeItem('demo_token');
+    document.cookie = 'demo_cookie_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    setLocalToken('');
+    setCookieToken('');
+    setMemoryToken('');
+  };
+
+  return (
+    <div>
+      <h1>💾 Token Storage: localStorage vs Cookie vs Memory</h1>
+      <div style={styles.card}>
+        <p>
+          Different storage mechanisms for tokens (JWT, session IDs) have security and persistence trade-offs.
+        </p>
+
+        <div style={styles.grid}>
+          <div style={styles.box}>
+            <h3>📦 localStorage</h3>
+            <p>Persists across browser restarts. Accessible via any JS (XSS risk).</p>
+            <button onClick={saveToLocalStorage} style={styles.btn}>Save Demo Token</button>
+            <div><strong>Stored token:</strong> {localToken || '(empty)'}</div>
+          </div>
+
+          <div style={styles.box}>
+            <h3>🍪 Cookie (HttpOnly recommended but demo)</h3>
+            <p>Sent automatically with requests. Can be flagged HttpOnly (prevents JS access) but vulnerable to CSRF.</p>
+            <button onClick={saveToCookie} style={styles.btn}>Save Demo Cookie</button>
+            <div><strong>Cookie token:</strong> {cookieToken || '(empty)'}</div>
+          </div>
+
+          <div style={styles.box}>
+            <h3>🧠 In-Memory (React state)</h3>
+            <p>Not persistent - lost on page reload. Most secure against XSS but user must re-authenticate.</p>
+            <button onClick={saveToMemory} style={styles.btn}>Save Memory Token</button>
+            <div><strong>Memory token:</strong> {memoryToken || '(empty)'}</div>
+          </div>
+        </div>
+
+        <button onClick={clearAll} style={styles.clearBtn}>Clear All Storage</button>
+
+        <div style={styles.refreshNote}>
+          <p>🔄 <strong>Try refreshing the page:</strong></p>
+          <ul>
+            <li>localStorage token persists ✅</li>
+            <li>Cookie token persists ✅ (if not expired)</li>
+            <li>Memory token resets to empty ❌</li>
+          </ul>
+          <p>🔐 Security tip: For SPAs, many apps store tokens in memory + refresh token in httpOnly cookie.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  card: { background: '#f8f9fa', padding: '1.5rem', borderRadius: '8px' },
+  grid: { display: 'flex', gap: '1rem', flexWrap: 'wrap', marginBottom: '1rem' },
+  box: { flex: '1', background: '#fff', padding: '1rem', borderRadius: '6px', border: '1px solid #ced4da' },
+  btn: { margin: '0.5rem 0', padding: '0.3rem 0.8rem', cursor: 'pointer', background: '#007bff', color: 'white', border: 'none', borderRadius: '4px' },
+  clearBtn: { marginTop: '1rem', padding: '0.5rem 1rem', background: '#6c757d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' },
+  refreshNote: { background: '#e9ecef', padding: '1rem', marginTop: '1rem', borderRadius: '6px' },
+};
+
+export default StorageDemo;

--- a/routing-and-security/src/routes/XSSDemo.jsx
+++ b/routing-and-security/src/routes/XSSDemo.jsx
@@ -1,0 +1,370 @@
+import { useState } from 'react';
+
+function XSSDemo() {
+  const [vulnerableInput, setVulnerableInput] = useState(
+    '<b>Welcome back, Alex</b> <img src=x onerror="alert(\'XSS fired\')" />'
+  );
+  const [safeInput, setSafeInput] = useState(
+    '<b>Welcome back, Alex</b> <img src=x onerror="alert(\'XSS fired\')" />'
+  );
+  const [securityLog, setSecurityLog] = useState([]);
+
+  const [cookieSessionEnabled, setCookieSessionEnabled] = useState(true);
+  const [sameSiteMode, setSameSiteMode] = useState('none');
+  const [csrfTokenOnForm, setCsrfTokenOnForm] = useState(false);
+  const [csrfTokenOnServer, setCsrfTokenOnServer] = useState('secure-123');
+  const [requestResult, setRequestResult] = useState('No request yet');
+
+  const appendLog = (line) => {
+    setSecurityLog((prev) => [line, ...prev].slice(0, 7));
+  };
+
+  const usePayload = (payload) => {
+    setVulnerableInput(payload);
+    setSafeInput(payload);
+  };
+
+  const csrfProtectedTransfer = ({ crossSite, providedToken }) => {
+    const browserSendsCookie = cookieSessionEnabled && (sameSiteMode === 'none' || !crossSite);
+    const csrfTokenValid = providedToken && providedToken === csrfTokenOnServer;
+
+    if (!browserSendsCookie) {
+      return {
+        ok: false,
+        reason: 'Blocked: session cookie not sent (SameSite + cross-site request).',
+      };
+    }
+
+    if (!csrfTokenValid) {
+      return {
+        ok: false,
+        reason: 'Blocked: missing or invalid CSRF token.',
+      };
+    }
+
+    return {
+      ok: true,
+      reason: 'Success: transfer accepted (cookie + valid CSRF token).',
+    };
+  };
+
+  const runAttackSimulation = () => {
+    const result = csrfProtectedTransfer({ crossSite: true, providedToken: null });
+    setRequestResult(result.reason);
+    appendLog(`[attack] POST /transfer cross-site -> ${result.reason}`);
+  };
+
+  const runLegitTransfer = () => {
+    const providedToken = csrfTokenOnForm ? csrfTokenOnServer : null;
+    const result = csrfProtectedTransfer({ crossSite: false, providedToken });
+    setRequestResult(result.reason);
+    appendLog(`[user] POST /transfer same-site -> ${result.reason}`);
+  };
+
+  return (
+    <div>
+      <h1>Security Demos: XSS + CSRF (Real-world style)</h1>
+      <p style={styles.helperText}>
+        These examples mirror what happens in dashboards, comments, support notes, and payment actions.
+        The goal is to build practical engineering intuition, not only definitions.
+      </p>
+
+      <div style={styles.card}>
+        <h2 style={{ color: '#9f1239' }}>1) XSS: vulnerable rendering vs safe rendering</h2>
+        <p>
+          Scenario: product allows rich text in "internal notes" and directly injects user input into HTML.
+          One malicious note can execute script in every viewer&apos;s browser session.
+        </p>
+
+        <div style={styles.payloads}>
+          <button onClick={() => usePayload('<img src=x onerror="alert(\'XSS fired\')" />')} style={styles.payloadBtn}>
+            Use onerror payload
+          </button>
+          <button onClick={() => usePayload('<a href="javascript:alert(\'XSS fired\')">Click me</a>')} style={styles.payloadBtn}>
+            Use javascript: URL payload
+          </button>
+          <button onClick={() => usePayload('<b>Normal formatting only</b>')} style={styles.payloadBtn}>
+            Use safe-looking markup
+          </button>
+        </div>
+
+        <div style={styles.twoCol}>
+          <div style={styles.col}>
+            <h3 style={styles.subHeading}>Vulnerable version</h3>
+            <p style={styles.small}>Uses <code>dangerouslySetInnerHTML</code> with unsanitized user input.</p>
+            <input
+              type="text"
+              placeholder="Enter untrusted HTML"
+              value={vulnerableInput}
+              onChange={(e) => setVulnerableInput(e.target.value)}
+              style={styles.input}
+            />
+            <div style={styles.vulnerableBox}>
+              <strong>Rendered output:</strong>
+              <div dangerouslySetInnerHTML={{ __html: vulnerableInput }} />
+            </div>
+          </div>
+
+          <div style={styles.col}>
+            <h3 style={styles.subHeading}>Safe version</h3>
+            <p style={styles.small}>Renders as text; React escapes HTML by default.</p>
+            <input
+              type="text"
+              placeholder="Enter same input"
+              value={safeInput}
+              onChange={(e) => setSafeInput(e.target.value)}
+              style={styles.input}
+            />
+            <div style={styles.safeBox}>
+              <strong>Rendered output:</strong>
+              <div>{safeInput}</div>
+            </div>
+          </div>
+        </div>
+
+        <div style={styles.noteBox}>
+          <strong>Engineering takeaway:</strong> if rich HTML is required, sanitize on server + sanitize again
+          before rendering + apply CSP. If rich HTML is not required, never use <code>dangerouslySetInnerHTML</code>.
+        </div>
+      </div>
+
+      <div style={styles.card}>
+        <h2 style={{ color: '#1d4ed8' }}>2) CSRF: why cookie auth is vulnerable without token checks</h2>
+        <p>
+          CSRF works when the browser automatically includes cookies on requests that a victim did not intend.
+          Defenses: CSRF token validation and SameSite cookies.
+        </p>
+
+        <div style={styles.twoCol}>
+          <div style={styles.csrfVuln}>
+            <h3 style={styles.subHeading}>Environment toggles</h3>
+            <label style={styles.checkboxLine}>
+              <input
+                type="checkbox"
+                checked={cookieSessionEnabled}
+                onChange={(e) => setCookieSessionEnabled(e.target.checked)}
+              />
+              Browser has session cookie
+            </label>
+            <label style={styles.label}>SameSite mode</label>
+            <select
+              value={sameSiteMode}
+              onChange={(e) => setSameSiteMode(e.target.value)}
+              style={styles.select}
+            >
+              <option value="none">None (least safe)</option>
+              <option value="lax">Lax</option>
+              <option value="strict">Strict</option>
+            </select>
+
+            <label style={styles.checkboxLine}>
+              <input
+                type="checkbox"
+                checked={csrfTokenOnForm}
+                onChange={(e) => setCsrfTokenOnForm(e.target.checked)}
+              />
+              Legit form includes CSRF token
+            </label>
+
+            <label style={styles.label}>Server expected CSRF token</label>
+            <input
+              value={csrfTokenOnServer}
+              onChange={(e) => setCsrfTokenOnServer(e.target.value)}
+              style={styles.input}
+            />
+          </div>
+
+          <div style={styles.csrfFixed}>
+            <h3 style={styles.subHeading}>Request simulations</h3>
+            <button onClick={runAttackSimulation} style={styles.dangerButton}>
+              Simulate malicious cross-site request
+            </button>
+            <button onClick={runLegitTransfer} style={styles.safeButton}>
+              Simulate legitimate user transfer
+            </button>
+
+            <div style={styles.resultBox}>
+              <strong>Latest result:</strong> {requestResult}
+            </div>
+
+            <p style={styles.small}>
+              Cross-site attack sends no trusted CSRF token. If server requires token, request is blocked.
+            </p>
+          </div>
+        </div>
+
+        <div style={styles.logBox}>
+          <strong>Security event log:</strong>
+          {securityLog.length === 0 ? (
+            <p style={styles.small}>No events yet. Run either simulation.</p>
+          ) : (
+            <ul style={styles.logList}>
+              {securityLog.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <div style={styles.card}>
+        <h2>3) Practical checklist for frontend engineers</h2>
+        <ul style={styles.checkList}>
+          <li>Never render untrusted input via <code>dangerouslySetInnerHTML</code> without sanitization.</li>
+          <li>Prefer framework-escaped rendering whenever possible.</li>
+          <li>Assume cookies are auto-sent; CSRF tokens must be verified server-side.</li>
+          <li>Use SameSite cookies as an extra layer, not the only protection.</li>
+          <li>Keep security controls testable with deterministic demo URLs and states.</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  card: {
+    background: '#f8f9fa',
+    padding: '1.2rem',
+    borderRadius: '8px',
+    marginBottom: '1.5rem',
+    border: '1px solid #dee2e6',
+  },
+  helperText: {
+    color: '#334155',
+    marginBottom: '1rem',
+    lineHeight: '1.5',
+  },
+  twoCol: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+    gap: '1rem',
+    marginTop: '0.6rem',
+  },
+  col: {
+    background: '#f8fafc',
+    border: '1px solid #e2e8f0',
+    borderRadius: '6px',
+    padding: '0.8rem',
+  },
+  subHeading: {
+    marginBottom: '0.35rem',
+  },
+  small: {
+    color: '#475569',
+    fontSize: '0.9rem',
+    marginBottom: '0.5rem',
+  },
+  payloads: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.5rem',
+    marginTop: '0.6rem',
+    marginBottom: '0.6rem',
+  },
+  payloadBtn: {
+    border: '1px solid #94a3b8',
+    borderRadius: '6px',
+    padding: '0.35rem 0.7rem',
+    cursor: 'pointer',
+    background: '#ffffff',
+  },
+  input: {
+    width: '100%',
+    padding: '0.5rem',
+    margin: '0.5rem 0',
+    fontFamily: 'monospace',
+  },
+  vulnerableBox: {
+    background: '#f8d7da',
+    padding: '0.8rem',
+    border: '1px solid #f5c6cb',
+    borderRadius: '4px',
+    marginTop: '0.5rem',
+  },
+  safeBox: {
+    background: '#d4edda',
+    padding: '0.8rem',
+    border: '1px solid #c3e6cb',
+    borderRadius: '4px',
+    marginTop: '0.5rem',
+  },
+  noteBox: {
+    marginTop: '0.8rem',
+    background: '#fff7ed',
+    border: '1px solid #fed7aa',
+    borderRadius: '6px',
+    padding: '0.8rem',
+    lineHeight: '1.5',
+  },
+  csrfVuln: {
+    background: '#fce7f3',
+    border: '1px solid #fbcfe8',
+    padding: '1rem',
+    borderRadius: '6px',
+  },
+  csrfFixed: {
+    background: '#e0f2fe',
+    border: '1px solid #bae6fd',
+    padding: '1rem',
+    borderRadius: '6px',
+  },
+  checkboxLine: {
+    display: 'block',
+    marginBottom: '0.6rem',
+  },
+  label: {
+    display: 'block',
+    marginBottom: '0.25rem',
+    fontWeight: 600,
+    fontSize: '0.9rem',
+  },
+  select: {
+    width: '100%',
+    padding: '0.45rem',
+    marginBottom: '0.6rem',
+  },
+  dangerButton: {
+    background: '#e74c3c',
+    color: 'white',
+    border: 'none',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+    borderRadius: '4px',
+  },
+  safeButton: {
+    background: '#2ecc71',
+    color: 'white',
+    border: 'none',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+    borderRadius: '4px',
+    marginLeft: '0.5rem',
+  },
+  resultBox: {
+    marginTop: '1rem',
+    padding: '0.75rem',
+    background: '#fff3cd',
+    border: '1px solid #ffeeba',
+    borderRadius: '4px',
+  },
+  logBox: {
+    marginTop: '0.9rem',
+    background: '#f8fafc',
+    border: '1px solid #e2e8f0',
+    borderRadius: '6px',
+    padding: '0.8rem',
+  },
+  logList: {
+    marginTop: '0.45rem',
+    paddingLeft: '1rem',
+    fontFamily: 'monospace',
+    fontSize: '0.86rem',
+    lineHeight: '1.45',
+  },
+  checkList: {
+    paddingLeft: '1.1rem',
+    lineHeight: '1.6',
+  },
+};
+
+export default XSSDemo;

--- a/routing-and-security/src/routes/XSSDemo.jsx
+++ b/routing-and-security/src/routes/XSSDemo.jsx
@@ -9,10 +9,8 @@ function XSSDemo() {
   );
   const [securityLog, setSecurityLog] = useState([]);
 
-  const [cookieSessionEnabled, setCookieSessionEnabled] = useState(true);
-  const [sameSiteMode, setSameSiteMode] = useState('none');
   const [csrfTokenOnForm, setCsrfTokenOnForm] = useState(false);
-  const [csrfTokenOnServer, setCsrfTokenOnServer] = useState('secure-123');
+  const [fetchedCsrfToken, setFetchedCsrfToken] = useState(null);
   const [requestResult, setRequestResult] = useState('No request yet');
 
   const appendLog = (line) => {
@@ -24,41 +22,45 @@ function XSSDemo() {
     setSafeInput(payload);
   };
 
-  const csrfProtectedTransfer = ({ crossSite, providedToken }) => {
-    const browserSendsCookie = cookieSessionEnabled && (sameSiteMode === 'none' || !crossSite);
-    const csrfTokenValid = providedToken && providedToken === csrfTokenOnServer;
-
-    if (!browserSendsCookie) {
-      return {
-        ok: false,
-        reason: 'Blocked: session cookie not sent (SameSite + cross-site request).',
-      };
+  const fetchCsrfToken = async () => {
+    try {
+      const res = await fetch('/api/csrf-token');
+      const { csrfToken } = await res.json();
+      setFetchedCsrfToken(csrfToken);
+      appendLog(`[server] GET /api/csrf-token -> issued ${csrfToken.slice(0, 8)}…`);
+    } catch {
+      appendLog('[server] GET /api/csrf-token -> network error');
     }
-
-    if (!csrfTokenValid) {
-      return {
-        ok: false,
-        reason: 'Blocked: missing or invalid CSRF token.',
-      };
-    }
-
-    return {
-      ok: true,
-      reason: 'Success: transfer accepted (cookie + valid CSRF token).',
-    };
   };
 
-  const runAttackSimulation = () => {
-    const result = csrfProtectedTransfer({ crossSite: true, providedToken: null });
-    setRequestResult(result.reason);
-    appendLog(`[attack] POST /transfer cross-site -> ${result.reason}`);
+  // Always sends without a token — backend will reject with 403
+  const runAttackSimulation = async () => {
+    try {
+      const res = await fetch('/api/transfer', { method: 'POST' });
+      const data = await res.json();
+      setRequestResult(data.reason);
+      appendLog(`[attack] POST /api/transfer (no token) -> ${data.reason}`);
+    } catch {
+      appendLog('[attack] POST /api/transfer -> network error');
+    }
   };
 
-  const runLegitTransfer = () => {
-    const providedToken = csrfTokenOnForm ? csrfTokenOnServer : null;
-    const result = csrfProtectedTransfer({ crossSite: false, providedToken });
-    setRequestResult(result.reason);
-    appendLog(`[user] POST /transfer same-site -> ${result.reason}`);
+  // Sends with or without the token depending on the checkbox
+  const runLegitTransfer = async () => {
+    const headers = {};
+    if (csrfTokenOnForm && fetchedCsrfToken) {
+      headers['x-csrf-token'] = fetchedCsrfToken;
+    }
+    try {
+      const res = await fetch('/api/transfer', { method: 'POST', headers });
+      const data = await res.json();
+      setRequestResult(data.reason);
+      appendLog(`[user] POST /api/transfer ${csrfTokenOnForm ? '(token sent)' : '(no token)'} -> ${data.reason}`);
+      // Token is single-use; clear it so the next run requires a fresh fetch
+      if (data.ok) setFetchedCsrfToken(null);
+    } catch {
+      appendLog('[user] POST /api/transfer -> network error');
+    }
   };
 
   return (
@@ -137,58 +139,47 @@ function XSSDemo() {
 
         <div style={styles.twoCol}>
           <div style={styles.csrfVuln}>
-            <h3 style={styles.subHeading}>Environment toggles</h3>
-            <label style={styles.checkboxLine}>
-              <input
-                type="checkbox"
-                checked={cookieSessionEnabled}
-                onChange={(e) => setCookieSessionEnabled(e.target.checked)}
-              />
-              Browser has session cookie
-            </label>
-            <label style={styles.label}>SameSite mode</label>
-            <select
-              value={sameSiteMode}
-              onChange={(e) => setSameSiteMode(e.target.value)}
-              style={styles.select}
-            >
-              <option value="none">None (least safe)</option>
-              <option value="lax">Lax</option>
-              <option value="strict">Strict</option>
-            </select>
+            <h3 style={styles.subHeading}>Step 1 — get a real token from the server</h3>
+            <p style={styles.small}>
+              The backend issues a UUID, stores it server-side, and returns it here.
+              Each token is single-use and consumed on the first valid request.
+            </p>
+            <button onClick={fetchCsrfToken} style={styles.fetchButton}>
+              Fetch CSRF token from server
+            </button>
+            <div style={styles.tokenDisplay}>
+              <strong>Token held by this page:</strong><br />
+              {fetchedCsrfToken
+                ? <code style={{ wordBreak: 'break-all', fontSize: '0.82rem' }}>{fetchedCsrfToken}</code>
+                : <em style={{ color: '#64748b' }}>none — click Fetch first</em>}
+            </div>
 
-            <label style={styles.checkboxLine}>
+            <label style={{ ...styles.checkboxLine, marginTop: '1rem' }}>
               <input
                 type="checkbox"
                 checked={csrfTokenOnForm}
                 onChange={(e) => setCsrfTokenOnForm(e.target.checked)}
               />
-              Legit form includes CSRF token
+              &nbsp;Legit form sends token in <code>x-csrf-token</code> header
             </label>
-
-            <label style={styles.label}>Server expected CSRF token</label>
-            <input
-              value={csrfTokenOnServer}
-              onChange={(e) => setCsrfTokenOnServer(e.target.value)}
-              style={styles.input}
-            />
           </div>
 
           <div style={styles.csrfFixed}>
-            <h3 style={styles.subHeading}>Request simulations</h3>
+            <h3 style={styles.subHeading}>Step 2 — run a request</h3>
             <button onClick={runAttackSimulation} style={styles.dangerButton}>
-              Simulate malicious cross-site request
+              Simulate malicious request (no token)
             </button>
-            <button onClick={runLegitTransfer} style={styles.safeButton}>
-              Simulate legitimate user transfer
+            <button onClick={runLegitTransfer} style={{ ...styles.safeButton, marginLeft: 0, marginTop: '0.5rem', display: 'block' }}>
+              Simulate legitimate transfer
             </button>
 
             <div style={styles.resultBox}>
-              <strong>Latest result:</strong> {requestResult}
+              <strong>Backend response:</strong> {requestResult}
             </div>
 
             <p style={styles.small}>
-              Cross-site attack sends no trusted CSRF token. If server requires token, request is blocked.
+              The attack always omits the token → backend returns 403.<br />
+              The legit transfer passes or fails based on the checkbox above.
             </p>
           </div>
         </div>
@@ -318,10 +309,22 @@ const styles = {
     fontWeight: 600,
     fontSize: '0.9rem',
   },
-  select: {
-    width: '100%',
-    padding: '0.45rem',
-    marginBottom: '0.6rem',
+  fetchButton: {
+    background: '#6366f1',
+    color: 'white',
+    border: 'none',
+    padding: '0.45rem 0.9rem',
+    cursor: 'pointer',
+    borderRadius: '4px',
+  },
+  tokenDisplay: {
+    marginTop: '0.6rem',
+    background: '#f1f5f9',
+    border: '1px solid #cbd5e1',
+    borderRadius: '4px',
+    padding: '0.5rem 0.7rem',
+    fontSize: '0.85rem',
+    lineHeight: '1.5',
   },
   dangerButton: {
     background: '#e74c3c',
@@ -330,6 +333,8 @@ const styles = {
     padding: '0.5rem 1rem',
     cursor: 'pointer',
     borderRadius: '4px',
+    display: 'block',
+    width: '100%',
   },
   safeButton: {
     background: '#2ecc71',
@@ -338,7 +343,6 @@ const styles = {
     padding: '0.5rem 1rem',
     cursor: 'pointer',
     borderRadius: '4px',
-    marginLeft: '0.5rem',
   },
   resultBox: {
     marginTop: '1rem',

--- a/routing-and-security/src/routes/XSSDemo.jsx
+++ b/routing-and-security/src/routes/XSSDemo.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
 
 function XSSDemo() {
+  const { token } = useAuth();
   const [vulnerableInput, setVulnerableInput] = useState(
     '<b>Welcome back, Alex</b> <img src=x onerror="alert(\'XSS fired\')" />'
   );
@@ -24,7 +26,9 @@ function XSSDemo() {
 
   const fetchCsrfToken = async () => {
     try {
-      const res = await fetch('/api/csrf-token');
+      const res = await fetch('/api/csrf-token', {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
       const { csrfToken } = await res.json();
       setFetchedCsrfToken(csrfToken);
       appendLog(`[server] GET /api/csrf-token -> issued ${csrfToken.slice(0, 8)}…`);

--- a/routing-and-security/vite.config.js
+++ b/routing-and-security/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    open: true,
+  },
+});

--- a/routing-and-security/vite.config.js
+++ b/routing-and-security/vite.config.js
@@ -6,5 +6,8 @@ export default defineConfig({
   server: {
     port: 3000,
     open: true,
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
   },
 });


### PR DESCRIPTION

## What does this PR do?

Replaces the mock login and simulated CSRF demo with real flows backed by a minimal Express server. Login now validates against hardcoded credentials and returns a JWT. Protected routes redirect back to the originally requested URL after login. The CSRF demo makes real HTTP calls — the backend accepts or rejects based on a server-issued, single-use token in the request header.

> Video: https://drive.google.com/file/d/11EQ-QUwbE_c2cP0fxyQRy2C7o1yCwzYd/view?usp=sharing

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What was changed

**Backend (`server/`)** — minimal Express server on port 3001 with three endpoints:

- `POST /api/login` — validates `demo@example.com` / `password123`, returns a signed JWT. 401 on wrong credentials.
- `GET /api/csrf-token` — generates a `crypto.randomUUID()`, stores it in a server-side `Set`, and returns it to the caller.
- `POST /api/transfer` — reads the `x-csrf-token` request header, rejects with 403 if missing or not in the store, accepts and consumes the token on a valid match (single-use).

**`vite.config.js`** — `/api` proxy added pointing to `localhost:3001` so all frontend fetch calls are same-origin during dev.

**`AuthContext.jsx`** — `login()` is now async. It POSTs credentials to the backend and on success immediately fetches a CSRF token. Both the JWT and CSRF token are stored in React state (in-memory, cleared on logout). Return shape changed from `boolean` to `{ ok, error }`.

**`ProtectedRoute.jsx`** — reads `useLocation()` and passes `state: { from: location.pathname }` on the redirect to `/demo`, so the intended URL survives navigation.

**`DemoApp.jsx`** — `handleLogin` awaits the new return shape. After a successful login it reads `location.state?.from` and navigates there (`replace: true`), falling back to `/demo` when accessed directly. A banner shows the redirect target while the form is visible.

**`XSSDemo.jsx`** — CSRF section rewritten with real fetch calls. A "Fetch CSRF token" button calls `GET /api/csrf-token` and displays the UUID. The malicious-request button calls `POST /api/transfer` with no token header and receives a real 403. The legitimate-transfer button sends the token in `x-csrf-token` when the checkbox is on; the backend returns 200 and consumes the token. XSS section is unchanged.

## Changelog

```
Feature: Login now validates against a real backend and redirects users back to the page they originally tried to visit.
Feature: CSRF demo makes real HTTP requests — the backend issues, validates, and consumes single-use tokens.
```

## How to Test

1. Start the backend: `cd routing-and-security/server && npm start`
2. Start the frontend: `cd routing-and-security && npm run dev`
3. Navigate directly to `/admin` while logged out — confirm redirect to `/demo` with banner showing `/admin`
4. Log in with `demo@example.com` / `password123` — confirm redirect lands on `/admin`
5. Log in with wrong credentials — confirm error message, no redirect
6. Go to `/xss`, click **Fetch CSRF token from server** — confirm UUID appears
7. Check the **Legit form sends token** checkbox, click **Simulate legitimate transfer** — confirm backend returns success
8. Click **Simulate malicious request** — confirm 403 blocked response regardless of checkbox state
9. Run the legit transfer a second time without fetching a new token — confirm it is rejected (token was consumed)

## How QA Should Test

Affected workflows:

- Login flow and protected route access
- CSRF pass/fail demo on the `/xss` page

Specific checks:

- Unauthenticated visit to `/admin` → lands on `/demo` with redirect banner → login → lands on `/admin`
- Wrong credentials at `/demo` → error shown, stays on login form
- Logout → token and CSRF token cleared → `/admin` redirects again
- On `/xss`: fetch token → send legit transfer with checkbox on → 200 → token cleared from display
- On `/xss`: send attack without fetching → 403
- On `/xss`: fetch token → send legit transfer with checkbox off → 403 (token present on page but not sent)

## Rollback Plan

Revert this PR. The backend is a standalone `server/` directory with no shared state — removing it has no effect on the rest of the repository. The Vite proxy entry can be dropped from `vite.config.js` independently.

